### PR TITLE
Fix archiving tests

### DIFF
--- a/tests/test_log_archiving.py
+++ b/tests/test_log_archiving.py
@@ -18,7 +18,7 @@ def test_log_archive(tmpdir, backup, hook, num_tasks):
         "begin": "2020-01-01",
         "end": "2020-01-03",
     }
-    with pf.Suite("s", variables={"ECF_FILES": tmpdir}) as suite:
+    with pf.Suite("s", files=str(tmpdir)) as suite:
         with ArchivedRepeatFamily("main", repeat, backup, backup) as main:
             pf.Task("t1")
             with pf.Family("f1"):

--- a/tests/test_log_archiving.py
+++ b/tests/test_log_archiving.py
@@ -11,14 +11,14 @@ from wellies.log_archiving import ArchivedRepeatFamily
         [None, False, 2],
     ],
 )
-def test_log_archive(backup, hook, num_tasks):
+def test_log_archive(tmpdir, backup, hook, num_tasks):
     repeat = {
         "name": "YMD",
         "type": "RepeatDate",
         "begin": "2020-01-01",
         "end": "2020-01-03",
     }
-    with pf.Suite("s") as suite:
+    with pf.Suite("s", variables={"ECF_FILES": tmpdir}) as suite:
         with ArchivedRepeatFamily("main", repeat, backup, backup) as main:
             pf.Task("t1")
             with pf.Family("f1"):

--- a/wellies/log_archiving.py
+++ b/wellies/log_archiving.py
@@ -79,16 +79,13 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
             return
         script = textwrap.dedent(
             f"""
-            dir=$LOGS_BACKUP/$SUITE/$FAM
+            dir=$LOGS_BACKUP/$SUITE/$FAMILY
             dir_old=${{dir}}.${self.repeat_attr.name}
             [[ -d $dir ]] && mv $dir $dir_old
             """
         )
         return pf.Task(
             name="loop_logs",
-            variables={
-                "FAM": "%FAMILY%",
-            },
             script=[script],
         )
 
@@ -97,16 +94,16 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
             return
         script = textwrap.dedent(
             f"""
-            dir=$LOGS_BACKUP/$SUITE/$FAM
+            dir=$LOGS_BACKUP/$SUITE/$FAMILY
             dir_tar=$LOGS_BACKUP/$SUITE
 
             if [[ -d $dir_tar ]]; then
                 cd $dir_tar
 
-                for log in $(ls -d ${{FAM}}.*); do
+                for log in $(ls -d ${{FAMILY}}.*); do
                     REPEAT_TO_TAR=$(echo $log | awk -F'.' '{{print $NF}}')
                     if [[ $REPEAT_TO_TAR -lt ${self.repeat_attr.name} ]]; then
-                        TAR_FILE=${{FAM}}_${{REPEAT_TO_TAR}}.tar.gz
+                        TAR_FILE=${{FAMILY}}_${{REPEAT_TO_TAR}}.tar.gz
                         tar -czvf $TAR_FILE $log
                         chmod 644 $TAR_FILE
                         ecp -p $TAR_FILE ${{LOGS_ARCHIVE}}/$TAR_FILE
@@ -120,9 +117,6 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
         )
         return pf.Task(
             name="archive_logs",
-            variables={
-                "FAM": "%FAMILY%",
-            },
             script=[script],
         )
 

--- a/wellies/log_archiving.py
+++ b/wellies/log_archiving.py
@@ -37,7 +37,8 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
                 )
             variables["LOGS_ARCHIVE"] = logs_archive
         exit_hooks = kwargs.pop("exit_hook", [])
-        exit_hooks.append(self.exit_hook())
+        if self.exit_hook() and self.exit_hook() not in exit_hooks:
+            exit_hooks.append(self.exit_hook())
         super().__init__(
             name=name,
             exit_hook=exit_hooks,
@@ -52,7 +53,7 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
 
     def exit_hook(self):
         if not self.logs_backup:
-            return ""
+            return None
         return textwrap.dedent(
             """
             JOBOUT=%ECF_JOBOUT%

--- a/wellies/log_archiving.py
+++ b/wellies/log_archiving.py
@@ -52,7 +52,7 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
 
     def exit_hook(self):
         if not self.logs_backup:
-            return None
+            return ""
         return textwrap.dedent(
             """
             JOBOUT=%ECF_JOBOUT%

--- a/wellies/log_archiving.py
+++ b/wellies/log_archiving.py
@@ -79,13 +79,16 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
             return
         script = textwrap.dedent(
             f"""
-            dir=$LOGS_BACKUP/$SUITE/$FAMILY
+            dir=$LOGS_BACKUP/$SUITE/$FAM
             dir_old=${{dir}}.${self.repeat_attr.name}
             [[ -d $dir ]] && mv $dir $dir_old
             """
         )
         return pf.Task(
             name="loop_logs",
+            variables={
+                "FAM": "%FAMILY%",
+            },
             script=[script],
         )
 
@@ -94,16 +97,16 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
             return
         script = textwrap.dedent(
             f"""
-            dir=$LOGS_BACKUP/$SUITE/$FAMILY
+            dir=$LOGS_BACKUP/$SUITE/$FAM
             dir_tar=$LOGS_BACKUP/$SUITE
 
             if [[ -d $dir_tar ]]; then
                 cd $dir_tar
 
-                for log in $(ls -d ${{FAMILY}}.*); do
+                for log in $(ls -d ${{FAM}}.*); do
                     REPEAT_TO_TAR=$(echo $log | awk -F'.' '{{print $NF}}')
                     if [[ $REPEAT_TO_TAR -lt ${self.repeat_attr.name} ]]; then
-                        TAR_FILE=${{FAMILY}}_${{REPEAT_TO_TAR}}.tar.gz
+                        TAR_FILE=${{FAM}}_${{REPEAT_TO_TAR}}.tar.gz
                         tar -czvf $TAR_FILE $log
                         chmod 644 $TAR_FILE
                         ecp -p $TAR_FILE ${{LOGS_ARCHIVE}}/$TAR_FILE
@@ -117,6 +120,9 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
         )
         return pf.Task(
             name="archive_logs",
+            variables={
+                "FAM": "%FAMILY%",
+            },
             script=[script],
         )
 

--- a/wellies/log_archiving.py
+++ b/wellies/log_archiving.py
@@ -74,6 +74,8 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
         )
 
     def _loop_task(self):
+        if not self.logs_backup:
+            return
         script = textwrap.dedent(
             f"""
             dir=$LOGS_BACKUP/$SUITE/$FAMILY
@@ -87,6 +89,8 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
         )
 
     def _archive_task(self):
+        if not self.logs_backup:
+            return
         script = textwrap.dedent(
             f"""
             dir=$LOGS_BACKUP/$SUITE/$FAMILY


### PR DESCRIPTION
Add definition of ECF_FILES variable in archiving tests and remove generation of loop_logs and archiving_logs tasks if log_backup is not provided.