### PR TITLE
DRAFT - Adding passing of deploy user

### DIFF
--- a/wellies/config.py
+++ b/wellies/config.py
@@ -110,6 +110,10 @@ def concatenate_yaml_files(yaml_files):
         with open(yaml_path, "r") as file:
             local_options = yaml.load(file, Loader=yaml.SafeLoader)
 
+            # Skip empty files
+            if local_options is None:
+                continue
+
             # check for duplicates
             duplicated_keys = []
             for key in local_options.keys():

--- a/wellies/deployment.py
+++ b/wellies/deployment.py
@@ -91,6 +91,7 @@ def deploy_suite(
     name: str,
     hostname: str,
     deploy_dir: str,
+    deploy_user: str = None,
     backup_deploy: str = None,
     build_dir: str = None,
     no_prompt: bool = False,
@@ -113,6 +114,8 @@ def deploy_suite(
         The hostname of the remote repository.
     deploy_dir (str):
         The target to deploy the suite to.
+    deploy_user (str, optional):
+        The username to use for remote deployment. Defaults to None.
     backup_deploy (str, optional):
         The backup repository to use. Defaults to None.
     build_dir (str, optional):
@@ -141,10 +144,12 @@ def deploy_suite(
 
     _generate_suite(suite, staging_dir, name)
 
+    deploy_user = user if deploy_user is None else deploy_user
+
     try:
         deployer = ts.GitDeployment(
             host=hostname,
-            user=user,
+            user=deploy_user,
             staging_dir=staging_dir,
             local_repo=local_repo,
             target_repo=target_repo,
@@ -163,7 +168,7 @@ def deploy_suite(
         )
         deployer = ts.GitDeployment(
             host=hostname,
-            user=user,
+            user=deploy_user,
             staging_dir=staging_dir,
             local_repo=local_repo,
             target_repo=target_repo,

--- a/wellies/templates/suite.py_t
+++ b/wellies/templates/suite.py_t
@@ -29,6 +29,7 @@ class Config:
 
         self.deploy_dir = options['deploy_dir']
         self.deploy_hostname = options.get("deploy_hostname", "localhost")
+        self.deploy_user = options.get("deploy_user")
         self.backup_deploy = options.get('backup_deploy', None)
 
         self.output_root = options['output_root']
@@ -82,6 +83,7 @@ if __name__ == '__main__':
         name=config.name,
         hostname=config.deploy_hostname,
         deploy_dir=config.deploy_dir,
+        deploy_user=config.deploy_user,
         backup_deploy=config.backup_deploy,
         build_dir=args.build_dir,
         no_prompt=args.y,


### PR DESCRIPTION
This allows the configuration of a deployment user used for the tracksuite `GitDeployment` if the user and deployment user are different.