### PR TITLE
propose build_dir in data.yaml as only relevant for GitData(StaticData)

### DIFF
--- a/wellies/data.py
+++ b/wellies/data.py
@@ -136,7 +136,7 @@ class CopyData(StaticData):
 
 
 class GitData(StaticData):
-    def __init__(self, data_dir, name, options):
+    def __init__(self, data_dir, name, options, build_dir=None):
         files = options.get("files")
         if files is None:
             script = pf.TemplateScript(
@@ -147,7 +147,7 @@ class GitData(StaticData):
                 BRANCH=options.get("branch"),
             )
         else:
-            build_dir = options.get('build_dir', os.path.join(data_dir, "git"))
+            build_dir = build_dir if build_dir else os.path.join(data_dir, "git")
             if not isinstance(files, list):
                 files = [files]
             files = [os.path.join(build_dir, name, f) for f in files]
@@ -215,14 +215,14 @@ class MarsData(StaticData):
         super().__init__(data_dir, name, script, options)
 
 
-def parse_static_data_item(data_dir, name, options):
+def parse_static_data_item(data_dir, name, options, build_dir=None):
     type = options["type"]
     if type == "rsync":
         data = RsyncData(data_dir, name, options)
     elif type == "copy":
         data = CopyData(data_dir, name, options)
     elif type == "git":
-        data = GitData(data_dir, name, options)
+        data = GitData(data_dir, name, options, build_dir=build_dir)
     elif type == "ecfs":
         data = ECFSData(data_dir, name, options)
     elif type == "link":
@@ -237,7 +237,7 @@ def parse_static_data_item(data_dir, name, options):
 
 
 class StaticDataStore:
-    def __init__(self, data_dir: str, static_data_dict: dict):
+    def __init__(self, data_dir: str, static_data_dict: dict, build_dir=None):
         """
         The StaticDataStore contains a set of static data items and their
         associated scripts to be used to deploy the items when running the
@@ -253,7 +253,7 @@ class StaticDataStore:
         """
         self.static_data = {}
         for name, options in static_data_dict.items():
-            data = parse_static_data_item(data_dir, name, options)
+            data = parse_static_data_item(data_dir, name, options, build_dir=build_dir)
             self.static_data[name] = data
 
     def __getitem__(self, item):

--- a/wellies/data.py
+++ b/wellies/data.py
@@ -147,7 +147,6 @@ class GitData(StaticData):
                 BRANCH=options.get("branch"),
             )
         else:
-            build_dir = build_dir if build_dir else os.path.join(data_dir, "git")
             if not isinstance(files, list):
                 files = [files]
             files = [os.path.join(build_dir, name, f) for f in files]
@@ -237,7 +236,7 @@ def parse_static_data_item(data_dir, name, options, build_dir=None):
 
 
 class StaticDataStore:
-    def __init__(self, data_dir: str, static_data_dict: dict, build_dir=None):
+    def __init__(self, data_dir: str, static_data_dict: dict, build_dir: str=None):
         """
         The StaticDataStore contains a set of static data items and their
         associated scripts to be used to deploy the items when running the
@@ -250,7 +249,11 @@ class StaticDataStore:
         static_data_dict (dict):
             A dictionary containing the names of the static data items as
             keys and their deployment options as values.
+        data_dir (str):
+            The directory where data are staged on the running host when needed.
         """
+        self.data_dir = data_dir
+        self.build_dir = os.path.join(data_dir, "build") if build_dir is None else build_dir
         self.static_data = {}
         for name, options in static_data_dict.items():
             data = parse_static_data_item(data_dir, name, options, build_dir=build_dir)

--- a/wellies/data.py
+++ b/wellies/data.py
@@ -147,7 +147,7 @@ class GitData(StaticData):
                 BRANCH=options.get("branch"),
             )
         else:
-            build_dir = os.path.join(data_dir, "git")
+            build_dir = options.get('build_dir', os.path.join(data_dir, "git"))
             if not isinstance(files, list):
                 files = [files]
             files = [os.path.join(build_dir, name, f) for f in files]

--- a/wellies/data.py
+++ b/wellies/data.py
@@ -6,7 +6,7 @@ from wellies import mars, parse_yaml_files, scripts
 
 
 class DeployDataFamily(pf.AnchorFamily):
-    def __init__(self, data_store, exec_context={}, **kwargs):
+    def __init__(self, data_store, name='deploy_data', exec_context={}, **kwargs):
         """Defines "static_data" family contaning all tasks needed to deploy
         all types of datasets defined on a [data.StaticDataStore].
 
@@ -19,7 +19,7 @@ class DeployDataFamily(pf.AnchorFamily):
             An execution context mapping to configure each task submit
             arguments, by default {}
         """
-        super().__init__(name="deploy_data", **kwargs)
+        super().__init__(name=name, **kwargs)
 
         with self:
             has_tasks = False


### PR DESCRIPTION
Was considering putting build_dir as a top-level option, e.g. in config.yaml, and then pass it through the DatatStore instantiation as argument alongside data_dir. However, this requires lots of additions of build_dir=None as keyword argument in multiple levels of class instantiations. For example:
```
class GitData(StaticData):
    def __init__(self, data_dir, name, options, build_dir=None):
        build_dir = build_dir if build_dir is not None else os.path.join(data_dir, "git")
```
and then further above:
```
def parse_static_data_item(data_dir, name, options, build_dir=None):
    type = options["type"]
    ...
    elif type == "git":
        data = GitData(data_dir, name, options, build_dir=build_dir)
```
and also
```
class StaticDataStore:
    def __init__(self, data_dir: str, static_data_dict: dict, build_dir=None):
        self.static_data = {}
        for name, options in static_data_dict.items():
            data = parse_static_data_item(data_dir, name, options, build_dir=build_dir)
            self.static_data[name] = data
```
so that we can put in nodes.py or equivalent:
```
self.output_root = options['output_root']
self.build_dir = options.get('build_dir', os.path.join(self.output_root, 'build'))
static_data = options.get('static_data', {})
self.static_data = wellies.StaticDataStore(self.data_dir, static_data, build_dir=self.build_dir)
```
And ultimately is the build_dir the same for all git repos?

My understanding is that build_dir is only relevant for GitData(StaticData) class. Perhaps it's better to provide it with the static_data options? 
The price is potential duplication of paths defined in config.yaml and data.yaml if non-standard, i.e. other than $TMPDIR/build. 

I leave it to the developers to choose what they prefer as best aligned with the wellies spirit. I provide both options in two different commits.