### PR TITLE
Add 'custom' environment type

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,11 @@ def tools_config(custom_script_file):
                     "files": "environment.yaml",
                 },
             },
+            "customenv": {
+                "type": "custom",
+                "load": "source /path/to/env/load.sh",
+                "unload": "unloadenv",
+            }
         },
     }
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -277,6 +277,14 @@ class TestEnvToolsScripts(BaseToolScriptsTest):
 
         self._run(test_target, expected, tools_config)
 
+    def test_custom_env(self, tools_config):
+        test_target = "customenv"
+        expected = {
+            "load": ["source /path/to/env/load.sh"],
+            "unload": ["unloadenv"],
+        }
+        self._run(test_target, expected, tools_config)
+
 
 class TestPackageToolScripts(BaseToolScriptsTest):
     section = "packages"

--- a/wellies/tools.py
+++ b/wellies/tools.py
@@ -627,6 +627,14 @@ def parse_environment(
             conda_cmd=options.get("conda_cmd", "conda"),
             conda_activate_cmd=options.get("conda_activate_cmd", "conda"),
         )
+    elif type == "custom":
+        env = Tool(
+            name,
+            depends,
+            options.get("load", ""),
+            options.get("unload", ""),
+            options.get("setup", None),
+        )
     elif type == "venv":
         raise NotImplementedError("Pure virtual environment not implemented")
     else:


### PR DESCRIPTION
Open to discussion: I would like to have a generic environment that can declare custom load/unload commands, e.g. source a specific script. Alternatively we could restrict the `load` to be `source [...]`.