### PR TITLE
Refactor quickstart tests with fixture

### DIFF
--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -1,46 +1,50 @@
 # flake8: noqa
 import os
 import subprocess
-import tempfile
+
+import pytest
 
 from wellies.quickstart import main
 
 
-def quickstart():
-    suite_dir = tempfile.mkdtemp(prefix=f"test_suite_")
-    deploy_dir = tempfile.mkdtemp(prefix=f"deploy_")
+@pytest.fixture
+def quickstart_dirs(tmp_path):
+    """Generate a temporary quickstart project for the tests."""
+
+    suite_dir = tmp_path.joinpath("suite_dir")
+    deploy_dir = tmp_path.joinpath("deploy_dir")
+    suite_dir.mkdir()
+    deploy_dir.mkdir()
+
     main(
         [
-            f"{suite_dir}",
+            str(suite_dir),
             "-p",
             "test",
             "--deploy_root",
-            deploy_dir,
+            str(deploy_dir),
             "--output_root",
             "/my/output/root",
         ]
     )
-    print(suite_dir)
-    print(os.listdir(suite_dir))
-    print(os.listdir(os.path.join(suite_dir, "configs")))
 
-    return suite_dir, deploy_dir
+    yield str(suite_dir), str(deploy_dir)
 
 
-def test_quickstart():
-    suite_dir, deploy_dir = quickstart()
+def test_quickstart(quickstart_dirs):
+    suite_dir, deploy_dir = quickstart_dirs
     assert os.path.exists(os.path.join(suite_dir, "deploy.py"))
 
 
-def test_quickstart_help():
-    suite_dir, deploy_dir = quickstart()
+def test_quickstart_help(quickstart_dirs):
+    suite_dir, _ = quickstart_dirs
 
     # test help
     subprocess.check_call([f"{suite_dir}/deploy.py", "--help"])
 
 
-def test_quickstart_deploy():
-    suite_dir, deploy_dir = quickstart()
+def test_quickstart_deploy(quickstart_dirs):
+    suite_dir, deploy_dir = quickstart_dirs
 
     # test deployment
     subprocess.check_call(
@@ -55,8 +59,8 @@ def test_quickstart_deploy():
     assert os.path.exists(def_file)
 
 
-def test_quickstart_tools():
-    suite_dir, deploy_dir = quickstart()
+def test_quickstart_tools(quickstart_dirs):
+    suite_dir, deploy_dir = quickstart_dirs
 
     # test deployment
     subprocess.check_call(
@@ -72,8 +76,8 @@ def test_quickstart_tools():
     assert os.path.exists(def_file)
 
 
-def test_quickstart_exec_context():
-    suite_dir, deploy_dir = quickstart()
+def test_quickstart_exec_context(quickstart_dirs):
+    suite_dir, deploy_dir = quickstart_dirs
 
     # test deployment
     subprocess.check_call(


### PR DESCRIPTION
## Summary
- add a pytest fixture that sets up the quickstart project
- update tests to use the fixture

## Testing
- `pytest -q` *(fails: command not found)*