### PR TITLE
Feature: add virtual env tool

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,11 @@ def tools_config(custom_script_file):
                     "rsync_options": ["--chmod ug+rwx,o+r"],
                 },
             },
+            "anemoi_venv": {
+                "type": "venv",
+                "packages": ["anemoi_datasets"],
+                "depends": ["python"]
+            },
             "conda_exist": {
                 "type": "conda",
                 "environment": "/path/to/conda/env",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -147,6 +147,19 @@ class TestEnvToolsScripts(BaseToolScriptsTest):
 
         self._run(test_target, expected, tools_config)
 
+    def test_pure_venv(self, tools_config):
+        test_target = "anemoi_venv"
+        expected = {
+            "load": [f"source {self.lib_dir}/{test_target}/bin/activate"],
+            "unload": ["deactivate"],
+            "setup": [
+                f"rm -rf {self.lib_dir}/{test_target}",
+                f"python3 -m venv {self.lib_dir}/{test_target}",
+            ],
+        }
+
+        self._run(test_target, expected, tools_config)
+
     @pytest.mark.xfail(reason="pure venv not implemented")
     def test_rsync_venv(self, tools_config):
         test_target = "venv"

--- a/wellies/tools.py
+++ b/wellies/tools.py
@@ -636,7 +636,16 @@ def parse_environment(
             options.get("setup", None),
         )
     elif type == "venv":
-        raise NotImplementedError("Pure virtual environment not implemented")
+        venv_options = options.get("venv_options", "")
+        extra_packages = options.get("extra_packages", [])
+        env = VirtualEnvTool(
+            name,
+            lib_dir,
+            venv_options=venv_options,
+            extra_packages=extra_packages,
+            depends=depends,
+            options=options,
+        )
     else:
         raise Exception("Environment type {} not supported".format(type))
     return env


### PR DESCRIPTION
This adds a tool to create a python virtual env that does not use the system-wide site-packages

<!-- readthedocs-preview pyflow-wellies start -->
----
📚 Documentation preview 📚: https://pyflow-wellies--37.org.readthedocs.build/37/

<!-- readthedocs-preview pyflow-wellies end -->