### PR TITLE
Fix log archiving in presence of group node

### DIFF
--- a/wellies/log_archiving.py
+++ b/wellies/log_archiving.py
@@ -105,6 +105,8 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
             JOBDIR=$(dirname $ECF_JOBOUT)
             dir=$(echo $JOBDIR | sed -e s:$ECF_OUT:$LOGS_BACKUP:)
             dir_tar=$(dirname $dir)
+            archive_dir=$(echo $JOBDIR | sed -e s:$ECF_OUT:$LOGS_ARCHIVE:)
+            archive_dir=$(dirname $archive_dir)
 
             if [[ -d $dir_tar ]]; then
                 cd $dir_tar
@@ -115,7 +117,7 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
                         TAR_FILE=${{FAMILY1}}_${{REPEAT_TO_TAR}}.tar.gz
                         tar -czvf $TAR_FILE $log
                         chmod 644 $TAR_FILE
-                        ecp -p $TAR_FILE ${{LOGS_ARCHIVE}}/$TAR_FILE
+                        ecp -p $TAR_FILE ${{archive_dir}}/$TAR_FILE
 
                         rm -rf $log
                         rm -rf $TAR_FILE

--- a/wellies/log_archiving.py
+++ b/wellies/log_archiving.py
@@ -85,7 +85,9 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
             return
         script = textwrap.dedent(
             f"""
-            dir=$LOGS_BACKUP/$SUITE/$FAMILY
+            JOB=$(echo $JOB | sed -e "s:$ECF_HOME:$ECF_OUT:")
+            JOBDIR=$(echo ${{JOBOUT%%/*}})
+            dir=$(echo $JOBDIR | sed -e s:$ECF_OUT:$LOGS_BACKUP:)
             dir_old=${{dir}}.${self.repeat_attr.name}
             [[ -d $dir ]] && mv $dir $dir_old
             """
@@ -101,16 +103,18 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
             return
         script = textwrap.dedent(
             f"""
-            dir=$LOGS_BACKUP/$SUITE/$FAMILY
-            dir_tar=$LOGS_BACKUP/$SUITE
+            JOB=$(echo $JOB | sed -e "s:$ECF_HOME:$ECF_OUT:")
+            JOBDIR=$(echo ${{JOBOUT%%/*}})
+            dir=$(echo $JOBDIR | sed -e s:$ECF_OUT:$LOGS_BACKUP:)
+            dir_tar=$(dirname $dir)
 
             if [[ -d $dir_tar ]]; then
                 cd $dir_tar
 
-                for log in $(ls -d ${{FAMILY}}.*); do
+                for log in $(ls -d ${{FAMILY1}}.*); do
                     REPEAT_TO_TAR=$(echo $log | awk -F'.' '{{print $NF}}')
                     if [[ $REPEAT_TO_TAR -lt ${self.repeat_attr.name} ]]; then
-                        TAR_FILE=${{FAMILY}}_${{REPEAT_TO_TAR}}.tar.gz
+                        TAR_FILE=${{FAMILY1}}_${{REPEAT_TO_TAR}}.tar.gz
                         tar -czvf $TAR_FILE $log
                         chmod 644 $TAR_FILE
                         ecp -p $TAR_FILE ${{LOGS_ARCHIVE}}/$TAR_FILE

--- a/wellies/log_archiving.py
+++ b/wellies/log_archiving.py
@@ -85,10 +85,7 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
             return
         script = textwrap.dedent(
             f"""
-            ECF_HOME=%ECF_HOME%
-            
-            JOB=$(echo $ECF_JOBOUT | sed -e "s:$ECF_HOME:$ECF_OUT:")
-            JOBDIR=$(echo ${{ECF_JOBOUT%%/*}})
+            JOBDIR=$(dirname $ECF_JOBOUT)
             dir=$(echo $JOBDIR | sed -e s:$ECF_OUT:$LOGS_BACKUP:)
             dir_old=${{dir}}.${self.repeat_attr.name}
             [[ -d $dir ]] && mv $dir $dir_old
@@ -105,10 +102,7 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
             return
         script = textwrap.dedent(
             f"""
-            ECF_HOME=%ECF_HOME%
-
-            JOB=$(echo $ECF_JOBOUT | sed -e "s:$ECF_HOME:$ECF_OUT:")
-            JOBDIR=$(echo ${{ECF_JOBOUT%%/*}})
+            JOBDIR=$(dirname $ECF_JOBOUT)
             dir=$(echo $JOBDIR | sed -e s:$ECF_OUT:$LOGS_BACKUP:)
             dir_tar=$(dirname $dir)
 

--- a/wellies/log_archiving.py
+++ b/wellies/log_archiving.py
@@ -98,7 +98,7 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
         )
 
     def _archive_task(self):
-        if not self.logs_backup:
+        if not self.logs_backup or not self.logs_archive:
             return
         script = textwrap.dedent(
             f"""

--- a/wellies/log_archiving.py
+++ b/wellies/log_archiving.py
@@ -98,7 +98,7 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
         )
 
     def _archive_task(self):
-        if not self.logs_backup or not self.logs_archive:
+        if not self.logs_archive:
             return
         script = textwrap.dedent(
             f"""

--- a/wellies/log_archiving.py
+++ b/wellies/log_archiving.py
@@ -85,8 +85,10 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
             return
         script = textwrap.dedent(
             f"""
-            JOB=$(echo $JOB | sed -e "s:$ECF_HOME:$ECF_OUT:")
-            JOBDIR=$(echo ${{JOBOUT%%/*}})
+            ECF_HOME=%ECF_HOME%
+            
+            JOB=$(echo $ECF_JOBOUT | sed -e "s:$ECF_HOME:$ECF_OUT:")
+            JOBDIR=$(echo ${{ECF_JOBOUT%%/*}})
             dir=$(echo $JOBDIR | sed -e s:$ECF_OUT:$LOGS_BACKUP:)
             dir_old=${{dir}}.${self.repeat_attr.name}
             [[ -d $dir ]] && mv $dir $dir_old
@@ -103,8 +105,10 @@ class ArchivedRepeatFamily(pf.AnchorFamily):
             return
         script = textwrap.dedent(
             f"""
-            JOB=$(echo $JOB | sed -e "s:$ECF_HOME:$ECF_OUT:")
-            JOBDIR=$(echo ${{JOBOUT%%/*}})
+            ECF_HOME=%ECF_HOME%
+
+            JOB=$(echo $ECF_JOBOUT | sed -e "s:$ECF_HOME:$ECF_OUT:")
+            JOBDIR=$(echo ${{ECF_JOBOUT%%/*}})
             dir=$(echo $JOBDIR | sed -e s:$ECF_OUT:$LOGS_BACKUP:)
             dir_tar=$(dirname $dir)
 


### PR DESCRIPTION
In the presence of a group node, the directory paths determined in the exit hook don't match the directories searched in the looping or archiving tasks. Directory paths in the loop and archiving tasks have been changed to match the one defined in the exit hook.

Also, archiving task is omitted when the `logs_archive` is not defined.