### PR TITLE
fix setup with extra packages specs using '<' or '>'. Always quote

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -138,7 +138,7 @@ class TestEnvToolsScripts(BaseToolScriptsTest):
         extra_pkgs = tools_config["environments"][test_target][
             "extra_packages"
         ]
-        extra_pkgs = " ".join(extra_pkgs)
+        extra_pkgs = " ".join([f"'{pkg}'" for pkg in extra_pkgs])
 
         expected = {
             "load": [f"source {self.lib_dir}/{test_target}/bin/activate"],
@@ -277,7 +277,7 @@ class TestEnvToolsScripts(BaseToolScriptsTest):
         extra_pkgs = tools_config["environments"][test_target][
             "extra_packages"
         ]
-        extra_pkgs = " ".join(extra_pkgs)
+        extra_pkgs = " ".join([f"'{pkg}'" for pkg in extra_pkgs])
         conda_cmd = tools_config["environments"][test_target]["conda_cmd"]
 
         expected = {

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -138,7 +138,15 @@ class TestEnvToolsScripts(BaseToolScriptsTest):
         extra_pkgs = tools_config["environments"][test_target][
             "extra_packages"
         ]
-        extra_pkgs = " ".join([f"'{pkg}'" for pkg in extra_pkgs])
+        pkgs_str = ""
+        ws = ""
+        for pkg in extra_pkgs:
+            pkgs_str += (
+                f"{ws}'{pkg}'"
+                if set(pkg).intersection(set("><"))
+                else f"{ws}{pkg}"
+            )
+            ws = " "
 
         expected = {
             "load": [f"source {self.lib_dir}/{test_target}/bin/activate"],
@@ -146,7 +154,7 @@ class TestEnvToolsScripts(BaseToolScriptsTest):
             "setup": [
                 f"rm -rf {self.lib_dir}/{test_target}",
                 f"python3 -m venv {self.lib_dir}/{test_target}  --system-site-packages",
-                f"pip install {extra_pkgs}",
+                f"pip install {pkgs_str}",
             ],
         }
 
@@ -277,7 +285,15 @@ class TestEnvToolsScripts(BaseToolScriptsTest):
         extra_pkgs = tools_config["environments"][test_target][
             "extra_packages"
         ]
-        extra_pkgs = " ".join([f"'{pkg}'" for pkg in extra_pkgs])
+        pkgs_str = ""
+        ws = ""
+        for pkg in extra_pkgs:
+            pkgs_str += (
+                f"{ws}'{pkg}'"
+                if set(pkg).intersection(set("><"))
+                else f"{ws}{pkg}"
+            )
+            ws = " "
         conda_cmd = tools_config["environments"][test_target]["conda_cmd"]
 
         expected = {
@@ -289,7 +305,7 @@ class TestEnvToolsScripts(BaseToolScriptsTest):
             "unload": ["conda deactivate"],
             "setup": [
                 f"rm -rf {self.lib_dir}/{test_target}",
-                f"{conda_cmd} create -p {self.lib_dir}/{test_target} {extra_pkgs}",
+                f"{conda_cmd} create -p {self.lib_dir}/{test_target} {pkgs_str}",
             ],
         }
 

--- a/wellies/tools.py
+++ b/wellies/tools.py
@@ -354,7 +354,7 @@ class VirtualEnvTool(Tool):
         ]
         if extra_packages:
             setup.extend(load)
-            pkgs = " ".join(extra_packages)
+            pkgs = " ".join([f"'{pkg}'" for pkg in extra_packages])
             setup.append(f"pip install {pkgs}")
         super().__init__(name, depends, load, unload, setup, options=options)
 
@@ -544,7 +544,7 @@ class SimpleCondaEnvTool(CondaEnvTool):
             A dictionary of options for the tool, by default {}.
         """
         env_root = path.join(lib_dir, name)
-        packages_str = " ".join(packages)
+        packages_str = " ".join([f"'{pkg}'" for pkg in packages])
         setup = pf.TemplateScript(
             conda_create,
             ENV_DIR=env_root,

--- a/wellies/tools.py
+++ b/wellies/tools.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 from os import path
 from typing import Dict
 from typing import List
@@ -354,7 +355,7 @@ class VirtualEnvTool(Tool):
         ]
         if extra_packages:
             setup.extend(load)
-            pkgs = " ".join([f"'{pkg}'" for pkg in extra_packages])
+            pkgs = " ".join([shlex.quote(pkg) for pkg in extra_packages])
             setup.append(f"pip install {pkgs}")
         super().__init__(name, depends, load, unload, setup, options=options)
 
@@ -544,7 +545,7 @@ class SimpleCondaEnvTool(CondaEnvTool):
             A dictionary of options for the tool, by default {}.
         """
         env_root = path.join(lib_dir, name)
-        packages_str = " ".join([f"'{pkg}'" for pkg in packages])
+        packages_str = " ".join([shlex.quote(pkg) for pkg in packages])
         setup = pf.TemplateScript(
             conda_create,
             ENV_DIR=env_root,


### PR DESCRIPTION
### Description

Allow proper installation of `pip` or `conda` packages with `<` or `>` specs without bash wrong redirects.

```yaml
environments:
   myvenv:
      type: venv
      extra_packages: ["setuptools>=77", "wheel", 'numpy==1.*]
```

now results in something like

```shell
pip install 'setuptools>=77' 'wheel' 'numpy==1.*'
```

previously, the `setuptools` spec would be passed wrongly to pip

```shell
pip install setuptools>=77 wheel numpy==1.*
```


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 