### PR TITLE
add toolstore level options with default reporting of modules at end of load script

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -13,6 +13,7 @@ from wellies import tools
 def test_tool_store(custom_script_file):
     lib_dir = os.path.join("path", "to", "lib")
     tools_dict = {
+        "options": {"list_modules": True},
         "modules": {
             "python3": {"version": 3.8},
             "private": {
@@ -68,6 +69,10 @@ def test_tool_store(custom_script_file):
 
     assert toolstore.depends("bin") == ["private", "python3"]
     assert toolstore.depends("myenv2") == ["python3"]
+    assert "module list" in toolstore.load("myenv2")
+    assert "module list" in toolstore.load("myenv1")
+    toolstore.list_modules = False
+    assert "module list" not in toolstore.load("myenv2")
 
 
 class BaseToolScriptsTest:
@@ -441,6 +446,31 @@ class TestPackageToolScripts(BaseToolScriptsTest):
                 f"{custom_script}",
                 "ecflow_client --label=version $(if [[ -f version.txt ]]; then cat version.txt; else echo NA; fi)",
             ],
+        }
+
+        self._run(test_target, expected, tools_config)
+
+
+class TestModulesToolsScripts(BaseToolScriptsTest):
+    section = "modules"
+
+    def test_modules(self, tools_config):
+        test_target = "netcdf4"
+        tconfig = tools_config["modules"][test_target]
+        tversion = tconfig.get("version", "default")
+        target_label = f"{test_target}/{tversion}"
+
+        expected = {
+            "load": [
+                "set +ux",
+                f"module unload {test_target} || true",
+                f"module load {target_label}",
+                "set -ux",
+            ],
+            "unload": [
+                f"module unload {test_target}",
+            ],
+            "setup": [],
         }
 
         self._run(test_target, expected, tools_config)

--- a/wellies/tools.py
+++ b/wellies/tools.py
@@ -746,11 +746,13 @@ class ToolStore:
         """
         if options is None:
             options = {}
+        store_options = options.pop("options", {})
         self.modules = options.get("modules", {})
         self.packages = options.get("packages", {})
         self.environments = options.get("environments", {})
         self.env_vars = options.get("env_variables", {})
         self.dir = lib_dir
+        self.list_modules = store_options.get("list_modules", True)
 
         # Build tools
         self.tools = {}
@@ -830,7 +832,10 @@ class ToolStore:
         script["head"] = "# load tools and activate environment"
         for item in tools:
             script.update(self.tool_script("load", item))
-        return list(script.values())
+        load_scripts = list(script.values())
+        if self.list_modules:
+            load_scripts.append("module list")
+        return load_scripts
 
     def unload(self, tools: Union[List[str], str]):
         """


### PR DESCRIPTION
### Description

We have the `set [+-]ux` block around module to supress long outputs, but we lose the logging of modules versions. This adds, by default a `module list` call after the toolstore `load` script. 
To activate that, I added a `ToolStore` level `options` entry in the config to avoid having to deal with optionals over each tool type.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 