### PR TITLE
feat/add squashFS option to VirtualEnvTool

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,7 @@ def tools_config(custom_script_file):
                 "packages": ["earthkit"],
                 "extra_packages": ["python==3.10", "pandas>2", "xarray"],
             },
-            "myenv3": {
+            "squashfs_env": {
                 "type": "venv",
                 "packages": ["anemoi_datasets"],
                 "depends": "python3",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,12 @@ def tools_config(custom_script_file):
                 "packages": ["earthkit"],
                 "extra_packages": ["python==3.10", "pandas>2", "xarray"],
             },
+            "myenv3": {
+                "type": "venv",
+                "packages": ["anemoi_datasets"],
+                "depends": "python3",
+                "options": {"use_squashfs": True},
+            },
             "venv": {
                 "type": "venv",
                 "packages": ["earthkit"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def tools_config(custom_script_file):
                 "type": "venv",
                 "packages": ["anemoi_datasets"],
                 "depends": "python3",
-                "options": {"use_squashfs": True},
+                "use_squashfs": True,
             },
             "venv": {
                 "type": "venv",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 import os
+import shutil
 from functools import partial
 from textwrap import dedent
 
@@ -174,6 +175,10 @@ class TestEnvToolsScripts(BaseToolScriptsTest):
 
         self._run(test_target, expected, tools_config)
 
+    @pytest.mark.skipif(
+        not (shutil.which("mksquashfs") and shutil.which("squashfs-mount")),
+        reason="Required binaries to use squashfs option not found on path",
+    )
     def test_squashfs_venv(self, tools_config):
         test_target = "myenv3"
         expected = {

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -166,11 +166,13 @@ class TestEnvToolsScripts(BaseToolScriptsTest):
 
         self._run(test_target, expected, tools_config)
 
-    @pytest.mark.skipif(
-        not (shutil.which("mksquashfs") and shutil.which("squashfs-mount")),
-        reason="Required binaries to use squashfs option not found on path",
-    )
-    def test_squashfs_venv(self, tools_config):
+    def test_squashfs_venv(self, tools_config, monkeypatch):
+        def _which(binary):
+            if binary in {"mksquashfs", "squashfs-mount"}:
+                return f"/usr/bin/{binary}"
+            return None
+
+        monkeypatch.setattr(shutil, "which", _which)
         test_target = "squashfs_env"
         expected = {
             "load": [

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -42,6 +42,12 @@ def test_tool_store(custom_script_file):
                 "packages": ["mypackage1", "mypackage2"],
                 "depends": "python3",
             },
+            "myenv3": {
+                "type": "venv",
+                "packages": ["mypackage1", "mypackage2"],
+                "depends": "python3",
+                "options": {"use_squashfs": True},
+            },
         },
         "env_variables": {
             "bin": {
@@ -61,6 +67,7 @@ def test_tool_store(custom_script_file):
         "mypackage2": tools.PackageTool,
         "myenv1": tools.CondaEnvTool,
         "myenv2": tools.SystemEnvTool,
+        "myenv3": tools.VirtualEnvTool,
         "bin": tools.EnvVarTool,
     }
 
@@ -69,9 +76,11 @@ def test_tool_store(custom_script_file):
 
     assert toolstore.depends("bin") == ["private", "python3"]
     assert toolstore.depends("myenv2") == ["python3"]
+    assert "module list" in toolstore.load("myenv3")
     assert "module list" in toolstore.load("myenv2")
     assert "module list" in toolstore.load("myenv1")
     toolstore.list_modules = False
+    assert "module list" not in toolstore.load("myenv3")
     assert "module list" not in toolstore.load("myenv2")
 
 
@@ -160,6 +169,23 @@ class TestEnvToolsScripts(BaseToolScriptsTest):
             "setup": [
                 f"rm -rf {self.lib_dir}/{test_target}",
                 f"python3 -m venv {self.lib_dir}/{test_target}",
+            ],
+        }
+
+        self._run(test_target, expected, tools_config)
+
+    def test_squashfs_venv(self, tools_config):
+        test_target = "myenv3"
+        expected = {
+            "load": [
+                f"squashfs-mount {self.lib_dir}/{test_target}.sqsh:{self.lib_dir}/{test_target} -- bash -l",
+                f"source {self.lib_dir}/{test_target}/bin/activate",
+            ],
+            "unload": ["deactivate"],
+            "setup": [
+                f"rm -rf {self.lib_dir}/{test_target}",
+                f"python3 -m venv {self.lib_dir}/{test_target}",
+                f"mksquashfs {self.lib_dir}/{test_target} {self.lib_dir}/{test_target}.sqsh",
             ],
         }
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -43,12 +43,6 @@ def test_tool_store(custom_script_file):
                 "packages": ["mypackage1", "mypackage2"],
                 "depends": "python3",
             },
-            "myenv3": {
-                "type": "venv",
-                "packages": ["mypackage1", "mypackage2"],
-                "depends": "python3",
-                "options": {"use_squashfs": True},
-            },
         },
         "env_variables": {
             "bin": {
@@ -68,7 +62,6 @@ def test_tool_store(custom_script_file):
         "mypackage2": tools.PackageTool,
         "myenv1": tools.CondaEnvTool,
         "myenv2": tools.SystemEnvTool,
-        "myenv3": tools.VirtualEnvTool,
         "bin": tools.EnvVarTool,
     }
 
@@ -77,11 +70,9 @@ def test_tool_store(custom_script_file):
 
     assert toolstore.depends("bin") == ["private", "python3"]
     assert toolstore.depends("myenv2") == ["python3"]
-    assert "module list" in toolstore.load("myenv3")
     assert "module list" in toolstore.load("myenv2")
     assert "module list" in toolstore.load("myenv1")
     toolstore.list_modules = False
-    assert "module list" not in toolstore.load("myenv3")
     assert "module list" not in toolstore.load("myenv2")
 
 
@@ -180,7 +171,7 @@ class TestEnvToolsScripts(BaseToolScriptsTest):
         reason="Required binaries to use squashfs option not found on path",
     )
     def test_squashfs_venv(self, tools_config):
-        test_target = "myenv3"
+        test_target = "squashfs_env"
         expected = {
             "load": [
                 f"squashfs-mount {self.lib_dir}/{test_target}.sqsh:{self.lib_dir}/{test_target} -- bash -l",

--- a/wellies/tools.py
+++ b/wellies/tools.py
@@ -378,10 +378,9 @@ class VirtualEnvTool(Tool):
             # final setup step, create the squash image
             setup.append(f"mksquashfs {env_root} {env_root}.sqsh")
 
-            # first load step, mount the squash image
-            load.insert(
-                0, f"squashfs-mount {env_root}.sqsh:{env_root} -- bash -l"
-            )
+            # first load step, mount the squash image without starting a
+            # subshell so the remaining load commands can run normally.
+            load.insert(0, f"squashfs-mount {env_root}.sqsh:{env_root}")
 
         super().__init__(name, depends, load, unload, setup, options=options)
 
@@ -672,7 +671,7 @@ def parse_environment(
     elif type == "venv":
         venv_options = options.get("venv_options", "")
         extra_packages = options.get("extra_packages", [])
-        use_squashfs = options.get("options", {}).get("use_squashfs", False)
+        use_squashfs = options.get("use_squashfs", False)
         env = VirtualEnvTool(
             name,
             lib_dir,

--- a/wellies/tools.py
+++ b/wellies/tools.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from os import path
 from typing import Dict
 from typing import List
@@ -318,6 +319,7 @@ class VirtualEnvTool(Tool):
         extra_packages: Union[str, List[str]] = [],
         depends: List[str] = [],
         options: Dict[str, any] = {},
+        use_squashfs: bool = False,
     ):
         """
         A tool that creates a python virtual environment and sets the right
@@ -336,6 +338,12 @@ class VirtualEnvTool(Tool):
             A list of dependencies for the tool, by default [].
         options : Dict[str], optional
             A dictionary of options for the tool, by default {}.
+        use_squashfs : Bool, optional
+            If true, the virtual env will be squashed into a single squashFS file after venv creation.
+            When loading the env, the squashFS will first be mounted over the original env location.
+            This will speed up inital venv load times since only 1 file has to be loaded.
+            *Note* the 'squashfs-mount' tool is used to mount the squash-fs.
+            If this tool is not found on the path and 'use_squashfs=True' an error will be thrown.
         """
         env_root = path.join(lib_dir, name)
         load = [
@@ -356,6 +364,25 @@ class VirtualEnvTool(Tool):
             setup.extend(load)
             pkgs = " ".join(extra_packages)
             setup.append(f"pip install {pkgs}")
+
+        if use_squashfs:
+            # Ensure 'mksquashfs' and 'squashfs-mount' are on the path
+            has_required_deps = shutil.which("mksquashfs") and shutil.which(
+                "squashfs-mount"
+            )
+            if not has_required_deps:
+                raise ValueError(
+                    '"use_squashfs" option requested but required dependancies not found: "mksquashfs" and/or "squashfs-mount".'
+                )
+
+            # final setup step, create the squash image
+            setup.append(f"mksquashfs {env_root} {env_root}.sqsh")
+
+            # first load step, mount the squash image
+            load.insert(
+                0, f"squashfs-mount {env_root}.sqsh:{env_root} -- bash -l"
+            )
+
         super().__init__(name, depends, load, unload, setup, options=options)
 
 
@@ -645,6 +672,7 @@ def parse_environment(
     elif type == "venv":
         venv_options = options.get("venv_options", "")
         extra_packages = options.get("extra_packages", [])
+        use_squashfs = options.get("options", {}).get("use_squashfs", False)
         env = VirtualEnvTool(
             name,
             lib_dir,
@@ -652,6 +680,7 @@ def parse_environment(
             extra_packages=extra_packages,
             depends=depends,
             options=options,
+            use_squashfs=use_squashfs,
         )
     else:
         raise Exception("Environment type {} not supported".format(type))


### PR DESCRIPTION
### Description
This PR adds an option to the virtual env tool to use squashFS when creating a venv. This will speed up the loading of virtual environments.

Using squashFS packages an entire virtual env (consisting of many small files, hard on parallel file systems) into a single file. At runtime, the squashFS image is mounted, which makes the compressed image appear like a normal filesystem.

This option adds an additional step at the end of the 'setup' action to create the venv. And an additional option at runtime to mount the squashFS image. These steps rely on the binaries 'mksquashfs' and 'squashfs-mount'. If either tool aren't found on the path, this option will fail

I added a test and it passes (but this test appears to just match strings)
```bash
pytest tests/test_tools.py  -k test_squashfs
===================================================================== test session starts =====================================================================
platform linux -- Python 3.12.9, pytest-8.4.2, pluggy-1.6.0
rootdir: /lus/h2resw01/hpcperm/naco/squashfs-test/pyflow-wellies
configfile: pyproject.toml
plugins: anyio-4.12.0, hydra-core-1.3.2, typeguard-4.4.4, xdist-3.8.0, hypothesis-6.150.2, mock-3.15.1, skip-slow-0.0.5
collected 18 items / 17 deselected / 1 selected

tests/test_tools.py .                                                                                                                                   [100%]

============================================================== 1 passed, 17 deselected in 0.58s ==============================================================
```

I have also tested squashFS with anemoi venvs [here](https://confluence.ecmwf.int/display/~naco/Squashfs+venvs) 

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 