### PR TITLE
Include `server_ecfvars` in `get_host`

### DIFF
--- a/wellies/hosts.py
+++ b/wellies/hosts.py
@@ -81,6 +81,7 @@ def get_host(
         name="%HOST%",
         user=user,
         extra_variables=extra_variables,
+        server_ecfvars=server_ecfvars,
         ecflow_path=ecflow_path,
         submit_arguments=submit_arguments,
         **kwargs,


### PR DESCRIPTION
### Description
Bug fix to add missing kwarg `server_ecfvars`.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
