### PR TITLE
Fix ecflow_variables merge order breaking variable substitution

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -109,8 +109,13 @@ parsing configuration files may alter the final mapping of variables in the pres
 /// admonition | Note
     type: note
 
-The order of the configuration files may also alter the way template variables are dealt with. In this case,
-duplicates also overwrite previous values, and missing variables raise a `KeyError`.
+`ecflow_variables` are merged from all configuration files and substituted last,
+after every other configuration key. A variable's value can reference any other
+configuration key with `{...}` templating, regardless of which file defined it.
+The reverse is not supported: other configuration values cannot reference an
+`ecflow_variable` with `{...}` templating. To use an `ecflow_variable` in another
+value, use the ecFlow runtime form `${VAR:-default}`, which is expanded when the
+suite runs. Duplicate variable names across files resolve last-wins.
 ///
 
 Considering we have the following two configuration files:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -262,14 +262,21 @@ class TestYamlParser:
 
     def test_ecflow_variables_are_not_substitution_sources(self):
         # ecflow_variables merge in last, so other config values cannot
-        # reference them via {} templating. Use ${VAR} at runtime instead.
-        config = """
-        label: "run-{EXPVER}"
+        # reference them via {} templating. Use ecFlow or shell runtime
+        # expansion instead, depending on where the value is consumed.
+        config_1 = """
         ecflow_variables:
             EXPVER: "001"
         """
-        config_path = self._write("config", config)
-        options = concatenate_yaml_files([config_path])
+        config_1_path = self._write("config_1", config_1)
+
+        config_2 = """
+        label: "run-{EXPVER}"
+        """
+        config_2_path = self._write("config_2", config_2)
+
+        options = concatenate_yaml_files([config_1_path, config_2_path])
+
         with pytest.raises(KeyError):
             substitute_variables(options)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -239,6 +239,40 @@ class TestYamlParser:
         with pytest.raises(KeyError):
             concatenate_yaml_files([config_1_path, config_2_path])
 
+    def test_ecflow_variables_merge_order_substitution(self):
+        # An ecflow_variable defined in a later file can reference a normal
+        # key from that file, even if an earlier file also set ecflow_variables.
+        config_1 = """
+        ecflow_variables:
+            FOO: bar
+        """
+        config_1_path = self._write("config_1", config_1)
+
+        config_2 = """
+        root: /scratch
+        ecflow_variables:
+            DATADIR: "{root}/data"
+        """
+        config_2_path = self._write("config_2", config_2)
+
+        options = concatenate_yaml_files([config_1_path, config_2_path])
+        result = substitute_variables(options)
+
+        assert result["ecflow_variables"]["DATADIR"] == "/scratch/data"
+
+    def test_ecflow_variables_are_not_substitution_sources(self):
+        # ecflow_variables merge in last, so other config values cannot
+        # reference them via {} templating. Use ${VAR} at runtime instead.
+        config = """
+        label: "run-{EXPVER}"
+        ecflow_variables:
+            EXPVER: "001"
+        """
+        config_path = self._write("config", config)
+        options = concatenate_yaml_files([config_path])
+        with pytest.raises(KeyError):
+            substitute_variables(options)
+
     def test_overwrite_none(self):
         config = """
         user: dummy

--- a/wellies/config.py
+++ b/wellies/config.py
@@ -189,7 +189,7 @@ def concatenate_yaml_files(yaml_files):
             )
 
         options.update(local_options)
-        options.update(concat_options)
+    options.update(concat_options)
     return options
 
 


### PR DESCRIPTION
### Description

`ecflow_variables` can be defined across multiple profile files and gets merged into one dictionary. In a project where I'm using wellies, I ran into problems when using `ecflow_variables` spread across multiple files. Turns out the merged block keeps the dict position of the *first* file that defined it, and since `substitute_variables` resolves `{}` refs in insertion order, an `ecflow_variable` coming from a later file can't reference a normal key from that same later file. You get `KeyError: ... used before assignment`.

There are different ways to fix this, but I thought I'd propose the simplest one: We could move `options.update(concat_options)` out of the per-file loop in `concatenate_yaml_files` so `ecflow_variables` lands last in the merged dict and gets substituted after everything else. That way an `ecflow_variable` can reference any other key regardless of which file defined it.

The bit I want feedback on: this flips one direction. A normal value can no longer do `{SOME_ECFLOW_VAR}`. That only ever worked by accident of ordering, and the documented way to consume an ecflow_variable elsewhere is the runtime `${VAR:-default}` form anyway, so I doubt anyone relies on it, but it *is* a behaviour change so flagging it.

Happy about any feedback or thoughts. If you're more in favor of finding another fix, I might also just turn this into an issue temporarily until I get time to get back to this.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- readthedocs-preview pyflow-wellies start -->
----
📚 Documentation preview 📚: https://pyflow-wellies--67.org.readthedocs.build/67/

<!-- readthedocs-preview pyflow-wellies end -->