### PR TITLE
single assign with templated preserves types.

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -43,7 +43,8 @@ filename_template: "/path/to/file/{{fc_date}}"  # (4)!
 2. There are some global template variables automatically derived from the
    system. Note the capitalized reference. For a full list, check [here](#global-template-variables)
 3. Variables (bash or ecFlow) defined only on the task run environment can be referenced and will
-   be ignored by the substitution algorithm
+   be ignored by the substitution algorithm. Both the bare form `${ENVVAR}` and the ecFlow
+   default-value form `${VAR:-default}` are preserved unchanged.
 4. To escape the curly-brackets to use defined python template values that can
    be rendered in runtime, just double the brackets
 
@@ -64,6 +65,23 @@ dictionary like:
     "filename_template": "/path/to/file/{fc_date}",
 }
 ```
+
+/// admonition | Substitution semantics
+    type: info
+
+**Type preservation**: a pure `{key}` reference — where the entire value is just
+`{key}` and nothing else — forwards the original value unchanged, preserving its
+type. So `count: "{base_count}"` with `base_count: 10` yields the integer `10`,
+not the string `"10"`. Mixed interpolated strings such as `"{root}/{user}"` must
+produce a string and always do so.
+
+**Nested scoping**: substitution processes the YAML tree depth-first. A nested mapping
+inherits all variable bindings built up in the outer scope and may also define its own
+local keys that shadow outer ones within that block.
+
+**Lists are not supported**: `{...}` references placed inside YAML list values are not
+expanded and will remain as literal strings.
+///
 
 ### Global template variables
 
@@ -87,8 +105,29 @@ print(f"```\n{pretty}\n```")
 
 With `pyflow-wellies` <= 1.1.0 if one of the global variables is not defined, the substitution happens with
 an empty string. This can lead to unexpected results, specially when building system paths. In newer versions,
-the substitution will raise an error if the variable is not defined and used in one of the configuration files.
+the substitution will raise a `ValueError` if the variable is not defined in the environment and is referenced
+in one of the configuration files. Ensure the required environment variables are set before running wellies.
 ///
+
+### Command-line configuration overrides
+
+Any configuration key can be overridden at deploy time with the `-s KEY=VALUE` flag,
+without editing the YAML files:
+
+```bash
+./build.sh myprofile -s ecflow_server.user=alice -s root=/perm/alice
+```
+
+**Dot notation** targets nested keys: `ecflow_server.user` sets the `user` field inside
+the `ecflow_server` mapping.
+
+**Type preservation**: the command-line value is always received as a string, but is
+then coerced to match the type of the existing value in the configuration file. For
+example, if `count: 10` is in a YAML file, `-s count=20` sets it to the *integer* `20`,
+not the string `"20"`. Booleans accept `true`, `false`, `1`, `0`, `yes`, `no`, `on`,
+`off` (case-insensitive). An unrecognised boolean string raises a `WelliesConfigurationError`.
+
+If the key does not yet exist in the configuration, the value is kept as a plain string.
 
 In the following pages the specifics for other wellies' components will be
 detailed.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,13 @@
+import datetime
 from io import StringIO
 from os.path import join as pjoin
 
 import pytest
 import yaml
 
+from wellies.config import TemplateFormatter
 from wellies.config import concatenate_yaml_files
+from wellies.config import get_user_globals
 from wellies.config import nested_set
 from wellies.config import overwrite_entries
 from wellies.config import substitute_variables
@@ -93,6 +96,22 @@ class TestYamlParser:
 
         self._run(config_in, expected)
 
+    def test_nested_config_variable_using_duplicated_key(self):
+        config_in = """
+        user: dummy
+        ecflow_variables:
+            FOO: bar/{user}
+        """
+        config_1_path = self._write("config_1", config_in)
+
+        config_in2 = """
+        user: john
+        """
+        config_2_path = self._write("config_2", config_in2)
+
+        with pytest.raises(KeyError):
+            concatenate_yaml_files([config_1_path, config_2_path])
+
     def test_key_used_before_assingnment(self):
         config_in = """
         user: dummy
@@ -105,7 +124,7 @@ class TestYamlParser:
         with pytest.raises(KeyError):
             self._run(config_in, expected=None)
 
-    def test_force_to_str(self):
+    def test_pure_reference_preserves_scalar_type(self):
         config_in = """
         a_int: 1
         a_int_str: "1"
@@ -116,10 +135,24 @@ class TestYamlParser:
         expected = {
             "a_int": 1,
             "a_int_str": "1",
-            "b_int": "1",
-            "b_int_str": "1",
+            "b_int": 1,  # pure reference: int preserved
+            "b_int_str": "1",  # pure reference: str preserved
         }
         self._run(config_in, expected=expected)
+
+    def test_pure_reference_preserves_complex_type(self):
+        # datetime.date is a good proxy for any complex type that YAML parses
+        # natively. Currently `{date}` coerces the value to the string
+        # "2024-01-01" instead of forwarding datetime.date(2024, 1, 1).
+        config_in = """
+        date: 2024-01-01
+        initial_date: "{date}"
+        """
+        expected = {
+            "date": datetime.date(2024, 1, 1),
+            "initial_date": datetime.date(2024, 1, 1),
+        }
+        self._run(config_in, expected)
 
     @pytest.mark.xfail(
         reason="Substution inside lists not supported", strict=True
@@ -165,7 +198,7 @@ class TestYamlParser:
 
         self._run(config_in, expected)
 
-    def test_replace_any_object_as_str(self):
+    def test_pure_reference_preserves_type_interpolated_remains_str(self):
         config_in = """
         user: dummy
         height: 1.89
@@ -186,12 +219,12 @@ class TestYamlParser:
             "height": 1.89,
             "weight": 82,
             "surnames": ["foo", "boo"],
-            "family_name": "['foo', 'boo']",
-            "bmi_formula": "82/1.89^2",
+            "family_name": ["foo", "boo"],  # pure reference: list preserved
+            "bmi_formula": "82/1.89^2",  # interpolated: always str
             "nested": {
                 "user": "dummy",
-                "surnames": "['foo', 'boo']",
-                "bmi_formula": "82/1.89^2",
+                "surnames": ["foo", "boo"],  # pure reference: list preserved
+                "bmi_formula": "82/1.89^2",  # interpolated: always str
             },
         }
 
@@ -221,8 +254,6 @@ class TestYamlParser:
         options = concatenate_yaml_files(
             [config_1_path, config_2_path, config_3_path]
         )
-        print(options)
-        print(ref_options)
         assert options == ref_options
 
     def test_duplicates(self):
@@ -259,6 +290,114 @@ class TestYamlParser:
         result = substitute_variables(options)
 
         assert result["ecflow_variables"]["DATADIR"] == "/scratch/data"
+
+    def test_ecflow_variables_duplicate_last_wins(self):
+        config_1 = """
+        ecflow_variables:
+            EXPVER: "001"
+        """
+        config_1_path = self._write("config_1", config_1)
+
+        config_2 = """
+        ecflow_variables:
+            EXPVER: "002"
+        """
+        config_2_path = self._write("config_2", config_2)
+
+        options = concatenate_yaml_files([config_1_path, config_2_path])
+
+        assert options["ecflow_variables"]["EXPVER"] == "002"
+
+    def test_runtime_placeholders_are_preserved(self):
+        config_in = """
+        root: /scratch
+        filename: "{root}/${ENVVAR}/{{fc_date}}"
+        """
+
+        expected = {
+            "root": "/scratch",
+            "filename": "/scratch/${ENVVAR}/{fc_date}",
+        }
+
+        self._run(config_in, expected)
+
+    def test_runtime_default_placeholders_are_preserved(self):
+        config_in = """
+        root: /scratch
+        filename: "{root}/${MODULES_VERSION:-default}/{{fc_date}}"
+        """
+
+        expected = {
+            "root": "/scratch",
+            "filename": "/scratch/${MODULES_VERSION:-default}/{fc_date}",
+        }
+
+        self._run(config_in, expected)
+
+    def test_ecflow_variables_can_feed_runtime_placeholders(self):
+        # This currently works because ecFlow runtime placeholders are
+        # preserved, but this should be revisited because it blurs the
+        # boundary between wellies templating and suite runtime expansion.
+        config_1 = """
+        ecflow_variables:
+            EXPVER: "001"
+        """
+        config_1_path = self._write("config_1", config_1)
+
+        config_2 = """
+        label: "run-${EXPVER}"
+        """
+        config_2_path = self._write("config_2", config_2)
+
+        options = concatenate_yaml_files([config_1_path, config_2_path])
+        result = substitute_variables(options)
+
+        assert result["label"] == "run-${EXPVER}"
+
+    def test_get_user_globals_includes_expected_keys(self, monkeypatch):
+        monkeypatch.setenv("USER", "alice")
+        monkeypatch.setenv("HOME", "/home/alice")
+        monkeypatch.setenv("PERM", "/perm")
+        monkeypatch.setenv("HPCPERM", "/hpcperm")
+        monkeypatch.setenv("SCRATCH", "/scratch")
+        monkeypatch.setenv("PWD", "/work")
+        monkeypatch.setenv("_FORTESTING", "testing")
+
+        result = get_user_globals()
+
+        assert result["USER"] == "alice"
+        assert result["HOME"] == "/home/alice"
+        assert result["PERM"] == "/perm"
+        assert result["HPCPERM"] == "/hpcperm"
+        assert result["SCRATCH"] == "/scratch"
+        assert result["PWD"] == "/work"
+        assert result["_FORTESTING"] == "testing"
+        assert set(result) >= {"TODAY", "YESTERDAY"}
+        assert len(result["TODAY"]) == 8
+        assert len(result["YESTERDAY"]) == 8
+
+    def test_template_formatter_preserves_runtime_default_placeholder(self):
+        # This branch should remain explicit because it guards the parser-level
+        # treatment of ecFlow runtime defaults, not just the end result.
+        formatter = TemplateFormatter()
+
+        assert list(formatter.parse("${MODULES_VERSION:-default}")) == [
+            ("${MODULES_VERSION:-default}", None, None, None)
+        ]
+
+    def test_substitute_variables_custom_globals_override_defaults(self):
+        config_in = """
+        root: /scratch
+        label: "{ROOT_DIR}/{root}"
+        """
+        config_path = self._write("config", config_in)
+
+        with open(config_path, "r") as file:
+            options = yaml.load(file, Loader=yaml.SafeLoader)
+
+        result = substitute_variables(options, globals={"ROOT_DIR": "/custom"})
+
+        assert result["label"] == "/custom//scratch"
 
     def test_ecflow_variables_are_not_substitution_sources(self):
         # ecflow_variables merge in last, so other config values cannot

--- a/wellies/config.py
+++ b/wellies/config.py
@@ -313,12 +313,40 @@ def check_environment_variables_substitution(value: str) -> None:
                 raise ValueError(f"Environment variable {key} is not set")
 
 
+def _pure_reference_key(value: str) -> Optional[str]:
+    """Return the key name when *value* is exactly ``{key}``, else ``None``.
+
+    A pure reference forwards the original value unchanged, preserving its
+    type. Mixed strings such as ``"{a}/{b}"`` must go through string
+    formatting and always produce a string.
+    """
+    _PURE_REFERENCE_RE = re.compile(r"^\{([^{}]+)\}$")
+    m = _PURE_REFERENCE_RE.match(value)
+    return m.group(1) if m else None
+
+
+def _protect_runtime_variables(value: str) -> tuple[str, dict[str, str]]:
+    """Temporarily replace runtime-only placeholders so formatter ignores them."""
+    _RUNTIME_VARIABLE_PATTERN = re.compile(r"\$\{[^}]+\}")
+    protected = {}
+
+    def replace(match):
+        token = f"__WELLIES_RUNTIME_VAR_{len(protected)}__"
+        protected[token] = match.group(0)
+        return token
+
+    return _RUNTIME_VARIABLE_PATTERN.sub(replace, value), protected
+
+
 def substitute_variables(
     options: dict, globals: Optional[dict] = None
 ) -> dict:
     """Parse base configuration file using the keys on that same file to
     string format other values.
-    Replaced variables will always be of type string.
+
+    A pure ``{key}`` reference (the entire value is exactly ``{key}``) preserves
+    the original type of the referenced value. Mixed interpolated strings such
+    as ``"{a}/{b}"`` always produce a string.
 
     Parameters
     ----------
@@ -351,8 +379,17 @@ def substitute_variables(
             else:
                 if isinstance(value, str):
                     try:
-                        check_environment_variables_substitution(value)
-                        new = formatter.format(value, **newMapping)
+                        safe_value, protected_values = (
+                            _protect_runtime_variables(value)
+                        )
+                        check_environment_variables_substitution(safe_value)
+                        ref_key = _pure_reference_key(safe_value)
+                        if ref_key is not None and ref_key in newMapping:
+                            new = newMapping[ref_key]
+                        else:
+                            new = formatter.format(safe_value, **newMapping)
+                            for token, original in protected_values.items():
+                                new = new.replace(token, original)
                     except KeyError as err:
                         missing = err.args[0]
                         raise KeyError(


### PR DESCRIPTION
### Description
This pull request enhances the configuration substitution system to preserve the original type of referenced values when using pure `{key}` references, clarifies substitution semantics in the documentation, and expands test coverage to ensure correct behavior. It also improves handling of runtime placeholders.

**Type preservation and substitution logic:**

* Pure `{key}` references in YAML configuration now forward the original value and type (e.g., integer, list, or date), rather than always converting to a string. Mixed interpolated strings (like `"{root}/{user}"`) still produce strings. [[1]](diffhunk://#diff-efe93a154b4797e479b5de070ffcfd35bf33396a37c83a78e04fa8af634a790aR316-R349) [[2]](diffhunk://#diff-efe93a154b4797e479b5de070ffcfd35bf33396a37c83a78e04fa8af634a790aL354-R392)
* Runtime placeholders such as `${ENVVAR}` and `${VAR:-default}` are now explicitly preserved during substitution, ensuring compatibility with ecFlow and shell runtime expansion. [[1]](diffhunk://#diff-efe93a154b4797e479b5de070ffcfd35bf33396a37c83a78e04fa8af634a790aR316-R349) [[2]](diffhunk://#diff-efe93a154b4797e479b5de070ffcfd35bf33396a37c83a78e04fa8af634a790aL354-R392)

**Documentation improvements:**

* Updated `docs/configurations.md` to document type preservation in substitutions, clarify the handling of runtime placeholders, and add a section on command-line configuration overrides with type coercion. [[1]](diffhunk://#diff-804be1605cc42ad1f482af6e29e04df206198406112de3eb42ce18717ed7a46aL46-R47) [[2]](diffhunk://#diff-804be1605cc42ad1f482af6e29e04df206198406112de3eb42ce18717ed7a46aR69-R85) [[3]](diffhunk://#diff-804be1605cc42ad1f482af6e29e04df206198406112de3eb42ce18717ed7a46aL90-R131)

**Test coverage:**

* Added and expanded tests to verify type preservation for pure references, correct handling of complex types (like `datetime.date`), preservation of runtime placeholders, and correct merging/overriding behavior for configuration keys and environment variables. [[1]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528R1-R10) [[2]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528R99-R114) [[3]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528L108-R127) [[4]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528L119-R156) [[5]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528L168-R201) [[6]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528L189-R227) [[7]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528L224-L225) [[8]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528R294-R401)


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- readthedocs-preview pyflow-wellies start -->
----
📚 Documentation preview 📚: https://pyflow-wellies--68.org.readthedocs.build/68/

<!-- readthedocs-preview pyflow-wellies end -->