### PR TITLE
Define variable substitution scopes and tighten duplicate detection

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -43,7 +43,8 @@ filename_template: "/path/to/file/{{fc_date}}"  # (4)!
 2. There are some global template variables automatically derived from the
    system. Note the capitalized reference. For a full list, check [here](#global-template-variables)
 3. Variables (bash or ecFlow) defined only on the task run environment can be referenced and will
-   be ignored by the substitution algorithm
+   be ignored by the substitution algorithm. Both the bare form `${ENVVAR}` and the ecFlow
+   default-value form `${VAR:-default}` are preserved unchanged.
 4. To escape the curly-brackets to use defined python template values that can
    be rendered in runtime, just double the brackets
 
@@ -97,6 +98,19 @@ the top-level keys, substitution raises a `KeyError` — even if a nested mappin
 happens to define a key with the same name.
 ///
 
+/// admonition | Type preservation
+    type: info
+
+A **pure** `{key}` reference — where the entire value is exactly `{key}` and nothing
+else — forwards the original value unchanged, preserving its type. So
+`count: "{base_count}"` with `base_count: 10` yields the integer `10`, not the
+string `"10"`. Mixed interpolated strings such as `"{root}/{user}"` must produce
+a string and always do so.
+
+`{...}` references placed inside YAML list values are **not** expanded and will
+remain as literal strings.
+///
+
 ### Global template variables
 
 As a shortcut, access to some common system-wide variables is made available on  
@@ -119,8 +133,30 @@ print(f"```\n{pretty}\n```")
 
 With `pyflow-wellies` <= 1.1.0 if one of the global variables is not defined, the substitution happens with
 an empty string. This can lead to unexpected results, specially when building system paths. In newer versions,
-the substitution will raise an error if the variable is not defined and used in one of the configuration files.
+the substitution will raise a `ValueError` if the variable is not defined in the
+environment and is referenced in one of the configuration files. Ensure the required
+environment variables are set before running wellies.
 ///
+
+### Command-line configuration overrides
+
+Any configuration key can be overridden at deploy time with the `-s KEY=VALUE` flag,
+without editing the YAML files:
+
+```bash
+./build.sh myprofile -s ecflow_server.user=alice -s root=/perm/alice
+```
+
+**Dot notation** targets nested keys: `ecflow_server.user` sets the `user` field inside
+the `ecflow_server` mapping.
+
+**Type preservation**: the command-line value is always received as a string, but is
+then coerced to match the type of the existing value in the configuration file. For
+example, if `count: 10` is in a YAML file, `-s count=20` sets it to the *integer* `20`,
+not the string `"20"`. Booleans accept `true`, `false`, `1`, `0`, `yes`, `no`, `on`,
+`off` (case-insensitive). An unrecognised boolean string raises a `WelliesConfigurationError`.
+
+If the key does not yet exist in the configuration, the value is kept as a plain string.
 
 In the following pages the specifics for other wellies' components will be
 detailed.

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -65,6 +65,38 @@ dictionary like:
 }
 ```
 
+### Scoping rules
+
+Keys are resolved in the order they appear (top-level first, then nested mappings).
+Each nested mapping is given a **snapshot** of the substitution context that was built
+up to that point — it can reference any top-level key defined before it, but its own
+keys do **not** propagate back to the parent scope or to sibling mappings.
+
+```yaml title="scoping_example.yaml"
+name: global                # (1)!
+nested_a:
+    name: local             # (2)!
+    path: /vol/{name}       # (3)!
+nested_b:
+    path: /scratch/{name}   # (4)!
+top_path: /data/{name}      # (5)!
+```
+
+1. Top-level key available to everything.
+2. This shadows `name` only **inside** `nested_a`; it does not affect other scopes, but can be used within `nested_a`.
+3. Resolves to `/vol/local` — uses value within scope: `nested_a.name`.
+4. Resolves to `/scratch/global`.
+5. Resolves to `/data/global`.
+
+/// admonition | Note
+    type: note
+
+A key defined inside a nested mapping (e.g. `nested_a.name`) is **not** visible
+outside that mapping. If a top-level `{...}` reference cannot be resolved from
+the top-level keys, substitution raises a `KeyError` — even if a nested mapping
+happens to define a key with the same name.
+///
+
 ### Global template variables
 
 As a shortcut, access to some common system-wide variables is made available on  
@@ -109,13 +141,31 @@ parsing configuration files may alter the final mapping of variables in the pres
 /// admonition | Note
     type: note
 
+For ordinary (non-`ecflow_variables`) keys, duplicate detection treats a `null`
+value the same as any other value: if a key is present in an earlier file — even
+with a `null` value — redefining it in a later file raises a `KeyError`.
+///
+
+/// admonition | Note
+    type: note
+
 `ecflow_variables` are merged from all configuration files and substituted last,
-after every other configuration key. A variable's value can reference any other
-configuration key with `{...}` templating, regardless of which file defined it.
+after every other configuration key. Because of this ordering, a variable's value
+can reference any top-level configuration key with `{...}` templating, regardless
+of which file defined it.
+
+Within the merged `ecflow_variables` mapping, entries are resolved in insertion
+order. An entry can reference an earlier entry in the same mapping, but forward
+references (referencing a key defined later) will raise a `KeyError`.
+
 The reverse is not supported: other configuration values cannot reference an
 `ecflow_variable` with `{...}` templating. To use an `ecflow_variable` in another
 value, use the ecFlow runtime form `${VAR:-default}`, which is expanded when the
-suite runs. Duplicate variable names across files resolve last-wins.
+suite runs.
+
+Nested keys defined elsewhere in the configuration are **not** visible inside
+`ecflow_variables` substitution (see [Scoping rules](#scoping-rules)).
+Duplicate variable names across files resolve last-wins.
 ///
 
 Considering we have the following two configuration files:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -409,6 +409,20 @@ class TestYamlParser:
             "DATADIR": "/scratch/data",
         }
 
+    def test_duplicate_null_top_level_key_raises(self):
+        config_1 = """
+        name: null
+        """
+        config_1_path = self._write("config_1", config_1)
+
+        config_2 = """
+        name: foo
+        """
+        config_2_path = self._write("config_2", config_2)
+
+        with pytest.raises(KeyError, match="Following keys found"):
+            concatenate_yaml_files([config_1_path, config_2_path])
+
     def test_overwrite_none(self):
         config = """
         user: dummy

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -254,13 +254,14 @@ class TestYamlParser:
     def test_nested_sibling_scopes_are_isolated(self):
         options = {
             "name": "global",
-            "first": {"name": "local"},
+            "first": {"name": "local", "path": "/scratch/{name}"},
             "second": {"path": "/scratch/{name}"},
         }
 
         result = substitute_variables(options)
 
         assert result["first"]["name"] == "local"
+        assert result["first"]["path"] == "/scratch/local"
         assert result["second"]["path"] == "/scratch/global"
 
     def test_nested_values_are_not_parent_substitution_sources(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,13 @@
+import datetime
 from io import StringIO
 from os.path import join as pjoin
 
 import pytest
 import yaml
 
+from wellies.config import TemplateFormatter
 from wellies.config import concatenate_yaml_files
+from wellies.config import get_user_globals
 from wellies.config import nested_set
 from wellies.config import overwrite_entries
 from wellies.config import substitute_variables
@@ -105,7 +108,7 @@ class TestYamlParser:
         with pytest.raises(KeyError):
             self._run(config_in, expected=None)
 
-    def test_force_to_str(self):
+    def test_pure_reference_preserves_scalar_type(self):
         config_in = """
         a_int: 1
         a_int_str: "1"
@@ -116,10 +119,21 @@ class TestYamlParser:
         expected = {
             "a_int": 1,
             "a_int_str": "1",
-            "b_int": "1",
-            "b_int_str": "1",
+            "b_int": 1,  # pure reference: int preserved
+            "b_int_str": "1",  # pure reference: str preserved
         }
         self._run(config_in, expected=expected)
+
+    def test_pure_reference_preserves_complex_type(self):
+        config_in = """
+        date: 2024-01-01
+        initial_date: "{date}"
+        """
+        expected = {
+            "date": datetime.date(2024, 1, 1),
+            "initial_date": datetime.date(2024, 1, 1),
+        }
+        self._run(config_in, expected)
 
     @pytest.mark.xfail(
         reason="Substution inside lists not supported", strict=True
@@ -165,7 +179,7 @@ class TestYamlParser:
 
         self._run(config_in, expected)
 
-    def test_replace_any_object_as_str(self):
+    def test_pure_reference_preserves_type_interpolated_remains_str(self):
         config_in = """
         user: dummy
         height: 1.89
@@ -186,12 +200,12 @@ class TestYamlParser:
             "height": 1.89,
             "weight": 82,
             "surnames": ["foo", "boo"],
-            "family_name": "['foo', 'boo']",
-            "bmi_formula": "82/1.89^2",
+            "family_name": ["foo", "boo"],  # pure reference: list preserved
+            "bmi_formula": "82/1.89^2",  # interpolated: always str
             "nested": {
                 "user": "dummy",
-                "surnames": "['foo', 'boo']",
-                "bmi_formula": "82/1.89^2",
+                "surnames": ["foo", "boo"],  # pure reference: list preserved
+                "bmi_formula": "82/1.89^2",  # interpolated: always str
             },
         }
 
@@ -221,8 +235,6 @@ class TestYamlParser:
         options = concatenate_yaml_files(
             [config_1_path, config_2_path, config_3_path]
         )
-        print(options)
-        print(ref_options)
         assert options == ref_options
 
     def test_duplicates(self):
@@ -423,6 +435,147 @@ class TestYamlParser:
 
         with pytest.raises(KeyError, match="Following keys found"):
             concatenate_yaml_files([config_1_path, config_2_path])
+
+    def test_nested_config_variable_using_duplicated_key(self):
+        config_in = """
+        user: dummy
+        ecflow_variables:
+            FOO: bar/{user}
+        """
+        config_1_path = self._write("config_1", config_in)
+
+        config_in2 = """
+        user: john
+        """
+        config_2_path = self._write("config_2", config_in2)
+
+        with pytest.raises(KeyError):
+            concatenate_yaml_files([config_1_path, config_2_path])
+
+    def test_ecflow_variables_duplicate_last_wins(self):
+        config_1 = """
+        ecflow_variables:
+            EXPVER: "001"
+        """
+        config_1_path = self._write("config_1", config_1)
+
+        config_2 = """
+        ecflow_variables:
+            EXPVER: "002"
+        """
+        config_2_path = self._write("config_2", config_2)
+
+        options = concatenate_yaml_files([config_1_path, config_2_path])
+
+        assert options["ecflow_variables"]["EXPVER"] == "002"
+
+    def test_runtime_placeholders_are_preserved(self):
+        config_in = """
+        root: /scratch
+        filename: "{root}/${ENVVAR}/{{fc_date}}"
+        """
+
+        expected = {
+            "root": "/scratch",
+            "filename": "/scratch/${ENVVAR}/{fc_date}",
+        }
+
+        self._run(config_in, expected)
+
+    def test_runtime_default_placeholders_are_preserved(self):
+        config_in = """
+        root: /scratch
+        filename: "{root}/${MODULES_VERSION:-default}/{{fc_date}}"
+        """
+
+        expected = {
+            "root": "/scratch",
+            "filename": "/scratch/${MODULES_VERSION:-default}/{fc_date}",
+        }
+
+        self._run(config_in, expected)
+
+    def test_ecflow_variables_can_feed_runtime_placeholders(self):
+        # ecFlow runtime placeholders are preserved through wellies substitution
+        # so that they are expanded by ecFlow at suite runtime.
+        config_1 = """
+        ecflow_variables:
+            EXPVER: "001"
+        """
+        config_1_path = self._write("config_1", config_1)
+
+        config_2 = """
+        label: "run-${EXPVER}"
+        """
+        config_2_path = self._write("config_2", config_2)
+
+        options = concatenate_yaml_files([config_1_path, config_2_path])
+        result = substitute_variables(options)
+
+        assert result["label"] == "run-${EXPVER}"
+
+    def test_ecflow_variables_are_not_substitution_sources(self):
+        # ecflow_variables merge in last, so other config values cannot
+        # reference them via {} templating. Use ecFlow or shell runtime
+        # expansion instead, depending on where the value is consumed.
+        config_1 = """
+        ecflow_variables:
+            EXPVER: "001"
+        """
+        config_1_path = self._write("config_1", config_1)
+
+        config_2 = """
+        label: "run-{EXPVER}"
+        """
+        config_2_path = self._write("config_2", config_2)
+
+        options = concatenate_yaml_files([config_1_path, config_2_path])
+
+        with pytest.raises(KeyError):
+            substitute_variables(options)
+
+    def test_get_user_globals_includes_expected_keys(self, monkeypatch):
+        monkeypatch.setenv("USER", "alice")
+        monkeypatch.setenv("HOME", "/home/alice")
+        monkeypatch.setenv("PERM", "/perm")
+        monkeypatch.setenv("HPCPERM", "/hpcperm")
+        monkeypatch.setenv("SCRATCH", "/scratch")
+        monkeypatch.setenv("PWD", "/work")
+        monkeypatch.setenv("_FORTESTING", "testing")
+
+        result = get_user_globals()
+
+        assert result["USER"] == "alice"
+        assert result["HOME"] == "/home/alice"
+        assert result["PERM"] == "/perm"
+        assert result["HPCPERM"] == "/hpcperm"
+        assert result["SCRATCH"] == "/scratch"
+        assert result["PWD"] == "/work"
+        assert result["_FORTESTING"] == "testing"
+        assert set(result) >= {"TODAY", "YESTERDAY"}
+        assert len(result["TODAY"]) == 8
+        assert len(result["YESTERDAY"]) == 8
+
+    def test_template_formatter_preserves_runtime_default_placeholder(self):
+        formatter = TemplateFormatter()
+
+        assert list(formatter.parse("${MODULES_VERSION:-default}")) == [
+            ("${MODULES_VERSION:-default}", None, None, None)
+        ]
+
+    def test_substitute_variables_custom_globals_override_defaults(self):
+        config_in = """
+        root: /scratch
+        label: "{ROOT_DIR}/{root}"
+        """
+        config_path = self._write("config", config_in)
+
+        with open(config_path, "r") as file:
+            options = yaml.load(file, Loader=yaml.SafeLoader)
+
+        result = substitute_variables(options, globals={"ROOT_DIR": "/custom"})
+
+        assert result["label"] == "/custom//scratch"
 
     def test_overwrite_none(self):
         config = """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,7 +93,7 @@ class TestYamlParser:
 
         self._run(config_in, expected)
 
-    def test_key_used_before_assingnment(self):
+    def test_key_used_before_assignment(self):
         config_in = """
         user: dummy
         root: /scratch
@@ -239,6 +239,152 @@ class TestYamlParser:
         with pytest.raises(KeyError):
             concatenate_yaml_files([config_1_path, config_2_path])
 
+    def test_nested_values_do_not_shadow_parent_scope(self):
+        options = {
+            "name": "dummy",
+            "nested": {"name": "foo"},
+            "path": "/scratch/{name}",
+        }
+
+        result = substitute_variables(options)
+
+        assert result["nested"]["name"] == "foo"
+        assert result["path"] == "/scratch/dummy"
+
+    def test_nested_sibling_scopes_are_isolated(self):
+        options = {
+            "name": "global",
+            "first": {"name": "local"},
+            "second": {"path": "/scratch/{name}"},
+        }
+
+        result = substitute_variables(options)
+
+        assert result["first"]["name"] == "local"
+        assert result["second"]["path"] == "/scratch/global"
+
+    def test_nested_values_are_not_parent_substitution_sources(self):
+        options = {
+            "nested": {"name": "foo"},
+            "path": "/scratch/{name}",
+        }
+
+        with pytest.raises(
+            KeyError,
+            match='Variable substitution failed: Key "name" used before assignment',
+        ):
+            substitute_variables(options)
+
+    def test_merged_ecflow_variables_ignore_nested_scope_values(self):
+        config_1 = """
+        name: dummy
+        ecflow_variables:
+            LABEL: "{name}"
+        """
+        config_1_path = self._write("config_1", config_1)
+
+        config_2 = """
+        nested:
+            name: garbage
+        ecflow_variables:
+            DATADIR: "/scratch/{name}"
+        """
+        config_2_path = self._write("config_2", config_2)
+
+        options = concatenate_yaml_files([config_1_path, config_2_path])
+        result = substitute_variables(options)
+
+        assert result["ecflow_variables"] == {
+            "LABEL": "dummy",
+            "DATADIR": "/scratch/dummy",
+        }
+
+    def test_ecflow_variable_can_reference_key_from_later_file(self):
+        # Documents current behavior: ecflow_variables are substituted after all
+        # ordinary top-level keys, irrespective of which file defines those keys.
+        # Revisit this test if stricter cross-file dependency rules are introduced.
+        config_1 = """
+        ecflow_variables:
+            LABEL: "{name}"
+        """
+        config_1_path = self._write("config_1", config_1)
+
+        config_2 = """
+        name: foo
+        """
+        config_2_path = self._write("config_2", config_2)
+
+        options = concatenate_yaml_files([config_1_path, config_2_path])
+        result = substitute_variables(options)
+
+        assert result["ecflow_variables"]["LABEL"] == "foo"
+
+    def test_duplicate_ecflow_variables_use_last_value(self):
+        # Duplicate ecFlow variables currently use last-wins semantics, unlike
+        # ordinary top-level keys. Stricter validation may be preferable later.
+        config_1 = """
+        ecflow_variables:
+            LABEL: first
+        """
+        config_1_path = self._write("config_1", config_1)
+
+        config_2 = """
+        ecflow_variables:
+            LABEL: second
+        """
+        config_2_path = self._write("config_2", config_2)
+
+        options = concatenate_yaml_files([config_1_path, config_2_path])
+        result = substitute_variables(options)
+
+        assert result["ecflow_variables"]["LABEL"] == "second"
+
+    def test_ecflow_variable_can_reference_earlier_ecflow_variable(self):
+        # Merged ecFlow variables share a substitution scope and are resolved in
+        # insertion order. Stricter dependency validation may be preferable later.
+        config_1 = """
+        ecflow_variables:
+            ROOT: /scratch
+        """
+        config_1_path = self._write("config_1", config_1)
+
+        config_2 = """
+        ecflow_variables:
+            DATADIR: "{ROOT}/data"
+        """
+        config_2_path = self._write("config_2", config_2)
+
+        options = concatenate_yaml_files([config_1_path, config_2_path])
+        result = substitute_variables(options)
+
+        assert result["ecflow_variables"] == {
+            "ROOT": "/scratch",
+            "DATADIR": "/scratch/data",
+        }
+
+    def test_ecflow_variable_cannot_reference_later_ecflow_variable(self):
+        # Forward references within the merged ecFlow mapping currently fail
+        # because its entries are substituted in insertion order.
+        config_1 = """
+        ecflow_variables:
+            DATADIR: "{ROOT}/data"
+        """
+        config_1_path = self._write("config_1", config_1)
+
+        config_2 = """
+        ecflow_variables:
+            ROOT: /scratch
+        """
+        config_2_path = self._write("config_2", config_2)
+
+        options = concatenate_yaml_files([config_1_path, config_2_path])
+
+        with pytest.raises(
+            KeyError,
+            match='Variable substitution failed: Key "ROOT" used before assignment',
+        ):
+            substitute_variables(options)
+
     def test_ecflow_variables_merge_order_substitution(self):
         # An ecflow_variable defined in a later file can reference a normal
         # key from that file, even if an earlier file also set ecflow_variables.
@@ -258,27 +404,10 @@ class TestYamlParser:
         options = concatenate_yaml_files([config_1_path, config_2_path])
         result = substitute_variables(options)
 
-        assert result["ecflow_variables"]["DATADIR"] == "/scratch/data"
-
-    def test_ecflow_variables_are_not_substitution_sources(self):
-        # ecflow_variables merge in last, so other config values cannot
-        # reference them via {} templating. Use ecFlow or shell runtime
-        # expansion instead, depending on where the value is consumed.
-        config_1 = """
-        ecflow_variables:
-            EXPVER: "001"
-        """
-        config_1_path = self._write("config_1", config_1)
-
-        config_2 = """
-        label: "run-{EXPVER}"
-        """
-        config_2_path = self._write("config_2", config_2)
-
-        options = concatenate_yaml_files([config_1_path, config_2_path])
-
-        with pytest.raises(KeyError):
-            substitute_variables(options)
+        assert result["ecflow_variables"] == {
+            "FOO": "bar",
+            "DATADIR": "/scratch/data",
+        }
 
     def test_overwrite_none(self):
         config = """

--- a/wellies/config.py
+++ b/wellies/config.py
@@ -347,7 +347,7 @@ def substitute_variables(
             newMapping = {}
         for key, value in tree.items():
             if isinstance(value, abc.Mapping):
-                update(tree.get(key, {}), newMapping)
+                update(tree.get(key, {}), newMapping.copy())
             else:
                 if isinstance(value, str):
                     try:

--- a/wellies/config.py
+++ b/wellies/config.py
@@ -313,12 +313,39 @@ def check_environment_variables_substitution(value: str) -> None:
                 raise ValueError(f"Environment variable {key} is not set")
 
 
+def _pure_reference_key(value: str) -> Optional[str]:
+    """Return the key name when *value* is exactly ``{key}``, else ``None``.
+
+    A pure reference forwards the original value unchanged, preserving its
+    type. Mixed strings such as ``"{a}/{b}"`` must go through string
+    formatting and always produce a string.
+    """
+    m = re.compile(r"^\{([^{}]+)\}$").match(value)
+    return m.group(1) if m else None
+
+
+def _protect_runtime_variables(value: str) -> tuple[str, dict[str, str]]:
+    """Temporarily replace runtime-only placeholders so formatter ignores them."""
+    protected: dict[str, str] = {}
+
+    def replace(match: re.Match) -> str:
+        token = f"__WELLIES_RUNTIME_VAR_{len(protected)}__"
+        protected[token] = match.group(0)
+        return token
+
+    safe = re.compile(r"\$\{[^}]+\}").sub(replace, value)
+    return safe, protected
+
+
 def substitute_variables(
     options: dict, globals: Optional[dict] = None
 ) -> dict:
     """Parse base configuration file using the keys on that same file to
     string format other values.
-    Replaced variables will always be of type string.
+
+    A pure ``{key}`` reference (the entire value is exactly ``{key}``) preserves
+    the original type of the referenced value. Mixed interpolated strings such
+    as ``"{a}/{b}"`` always produce a string.
 
     Parameters
     ----------
@@ -351,8 +378,17 @@ def substitute_variables(
             else:
                 if isinstance(value, str):
                     try:
-                        check_environment_variables_substitution(value)
-                        new = formatter.format(value, **newMapping)
+                        safe_value, protected_values = (
+                            _protect_runtime_variables(value)
+                        )
+                        check_environment_variables_substitution(safe_value)
+                        ref_key = _pure_reference_key(safe_value)
+                        if ref_key is not None and ref_key in newMapping:
+                            new = newMapping[ref_key]
+                        else:
+                            new = formatter.format(safe_value, **newMapping)
+                            for token, original in protected_values.items():
+                                new = new.replace(token, original)
                     except KeyError as err:
                         missing = err.args[0]
                         raise KeyError(

--- a/wellies/config.py
+++ b/wellies/config.py
@@ -181,7 +181,7 @@ def concatenate_yaml_files(yaml_files):
         # check for duplicates
         duplicated_keys = []
         for key in local_options.keys():
-            if options.get(key) is not None:
+            if key in options:
                 duplicated_keys.append(key)
         if duplicated_keys:
             raise KeyError(


### PR DESCRIPTION
## Base changes

### Description

This change proposes to make variable substitution less flexible, but easier to reason about. Each nested dictionary receives a copy of its parent's substitution mapping. Parent values remain available to children, while values defined in nested dictionaries no longer leak into parent or sibling scopes. This reduces the substitution logic's dependence on dictionary traversal order.

This is a **breaking change** for configurations that rely on values leaking from nested scopes.

I also propose to detect duplicate top-level keys when the original value is YAML `null`.

This PR follows up on #67, which inadvertently exposed a more serious consequence of nested variable leakage: any nested value could override the substitution source used by ecflow_variables, which are now substituted last.

## From #68 

### Description
This pull request enhances the configuration substitution system to preserve the original type of referenced values when using pure `{key}` references, clarifies substitution semantics in the documentation, and expands test coverage to ensure correct behavior. It also improves handling of runtime placeholders.

**Type preservation and substitution logic:**

* Pure `{key}` references in YAML configuration now forward the original value and type (e.g., integer, list, or date), rather than always converting to a string. Mixed interpolated strings (like `"{root}/{user}"`) still produce strings. [[1]](diffhunk://#diff-efe93a154b4797e479b5de070ffcfd35bf33396a37c83a78e04fa8af634a790aR316-R349) [[2]](diffhunk://#diff-efe93a154b4797e479b5de070ffcfd35bf33396a37c83a78e04fa8af634a790aL354-R392)
* Runtime placeholders such as `${ENVVAR}` and `${VAR:-default}` are now explicitly preserved during substitution, ensuring compatibility with ecFlow and shell runtime expansion. [[1]](diffhunk://#diff-efe93a154b4797e479b5de070ffcfd35bf33396a37c83a78e04fa8af634a790aR316-R349) [[2]](diffhunk://#diff-efe93a154b4797e479b5de070ffcfd35bf33396a37c83a78e04fa8af634a790aL354-R392)

**Documentation improvements:**

* Updated `docs/configurations.md` to document type preservation in substitutions, clarify the handling of runtime placeholders, and add a section on command-line configuration overrides with type coercion. [[1]](diffhunk://#diff-804be1605cc42ad1f482af6e29e04df206198406112de3eb42ce18717ed7a46aL46-R47) [[2]](diffhunk://#diff-804be1605cc42ad1f482af6e29e04df206198406112de3eb42ce18717ed7a46aR69-R85) [[3]](diffhunk://#diff-804be1605cc42ad1f482af6e29e04df206198406112de3eb42ce18717ed7a46aL90-R131)

**Test coverage:**

* Added and expanded tests to verify type preservation for pure references, correct handling of complex types (like `datetime.date`), preservation of runtime placeholders, and correct merging/overriding behavior for configuration keys and environment variables. [[1]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528R1-R10) [[2]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528R99-R114) [[3]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528L108-R127) [[4]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528L119-R156) [[5]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528L168-R201) [[6]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528L189-R227) [[7]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528L224-L225) [[8]](diffhunk://#diff-da24b355349b53e4c8047034767d008e4c2ce9ea6c8933a3acd50d0828f00528R294-R401)

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- readthedocs-preview pyflow-wellies start -->
----
📚 Documentation preview 📚: https://pyflow-wellies--69.org.readthedocs.build/69/

<!-- readthedocs-preview pyflow-wellies end -->