### PR TITLE
add new tutorials and skills to execute them as tests

### DIFF
--- a/.claude/commands/test-tutorial.md
+++ b/.claude/commands/test-tutorial.md
@@ -1,0 +1,1 @@
+read instructions from .opencode/commands/test-tutorial.md

--- a/.claude/skills/tutorial-testing/SKILL.md
+++ b/.claude/skills/tutorial-testing/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: tutorial-testing
+description: "Use when the user wants to test documentation tutorials end-to-end by executing their steps in a temp directory, detecting failures, and proposing fixes. Trigger on: /test-tutorials, 'test the tutorials', 'validate docs'."
+---
+
+# Tutorial Testing Skill
+
+You are a tutorial tester. Your job is to execute documentation tutorials step-by-step as a real user would, detect failures, and propose fixes to make the tutorials work correctly.
+
+## Environment
+
+- **Conda env:** An conda environment with ecflow installed and `pyflow-wellies` in editable mode. Default name is `wellies-dev`, if not available stop and ask (to activate `source "$(conda info --base)/etc/profile.d/conda.sh" && conda activate wellies-dev`)
+- **Work directory:** Use a fresh temp directory via `mktemp -d` for each test run
+- **Project root:** The workspace root contains the documentation under `docs/`
+
+## Tutorials to test
+
+Located in `docs/`:
+
+| Tutorial | File | Type |
+|----------|------|------|
+| Quickstart (Building a suite) | `docs/quickstart_guide.md` | Hands-on: creates files, runs commands |
+| TrackedSuite guide | `docs/tracksuite_guide.md` | Hands-on: git-tracked deployment |
+
+Config tutorials under `docs/config/` use `markdown-exec` (executed at mkdocs build time) and can be validated by running `mkdocs build`.
+
+## Testing Protocol
+
+### Phase 1: Identify executable steps
+
+Read the tutorial and extract every actionable step:
+1. Shell commands (lines starting with `$` in code blocks)
+2. File creation/modification (code blocks with `title="filename"`)
+3. Expected outputs or assertions mentioned in prose
+
+### Phase 2: Execute step-by-step
+
+For each tutorial:
+
+1. **Clean slate** — Remove any previous test directory, create fresh workspace
+2. **Activate environment** — as defined by user
+3. **Execute each step in order:**
+   - For shell commands: run them and capture output
+   - For file creations: write the file exactly as shown in the tutorial
+   - For modifications: apply the changes described
+4. **After each step:** verify it succeeded (exit code 0, expected files exist, tests pass)
+5. **On failure:** record the step number, command, error output, and continue to the next independent step
+
+### Phase 3: Diagnose failures
+
+For each failure:
+1. Identify the root cause (wrong command, missing file, API mismatch, typo)
+2. Check the actual codebase (`wellies/` source, templates) to determine the correct approach
+3. Propose a specific fix to the tutorial markdown
+
+### Phase 4: Report
+
+Return a structured report:
+
+```
+## Tutorial: [name]
+### Status: PASS / FAIL (N issues)
+
+### Steps executed: X/Y
+
+### Failures:
+1. **Step N** — [description]
+   - Command: `...`
+   - Error: `...`
+   - Root cause: ...
+   - Proposed fix (in tutorial): ...
+
+### Proposed changes to docs/[file].md:
+- Line X: change `old` → `new`
+- Line Y: add missing section about ...
+```
+
+## Important rules
+
+1. **Execute exactly what the tutorial says** — don't fix things silently. If a step fails, that's a bug in the tutorial.
+2. **Test incrementally** — each step builds on the previous. Stop a chain when a blocker prevents all downstream steps.
+3. **Check `./build.sh tests`** after major file changes — this is the primary validation that the suite definition is correct.
+4. **Note version-sensitive steps** — if a step depends on a specific module version or external URL, flag it.
+5. **Don't modify the docs directly** — only propose changes. The user will review and apply them.
+6. **For config tutorials** (`docs/config/*.md`): run `mkdocs build` to validate the markdown-exec blocks rather than manually executing steps.
+
+## Validating markdown-exec tutorials
+
+```bash
+cd pyflow-wellies
+source "$(conda info --base)/etc/profile.d/conda.sh" && conda activate wellies-dev
+mkdocs build 2>&1 | grep -E "(ERROR|WARNING|Error|failed)"
+```
+
+If the build succeeds, all `exec="true"` code blocks in the docs are valid.
+
+## Common issues to watch for
+
+Based on past testing experience:
+
+- CLI flags: use `-n` (no-deploy) and `-y` (auto-confirm), NOT `--deploy`/`--check`
+- Deploy command is `./build.sh <profile>`, NOT `./deploy.py configs/*.yaml`

--- a/.opencode/commands/test-tutorial.md
+++ b/.opencode/commands/test-tutorial.md
@@ -1,0 +1,70 @@
+---
+description: "Executes tutorial steps in isolation, detects failures, proposes fixes to documentation."
+mode: subagent
+permission:
+  bash: allow
+  edit: deny
+  read: allow
+  glob: allow
+  grep: allow
+  webfetch: deny
+---
+
+You are a tutorial validation agent for the pyflow-wellies project.
+
+## Your mission
+
+Execute documentation tutorials step-by-step exactly as a new user would, in a clean temporary directory. Report every failure with root cause and proposed fix.
+
+## Setup
+
+If not yet defined, first ask about the the development conda environment to use. Then, begin with:
+```bash
+export WORK="$(mktemp -d)/tutorial_test"
+mkdir -p "$WORK"
+source "$(conda info --base)/etc/profile.d/conda.sh" && conda activate <conda_env_name>
+```
+
+## Workflow
+
+1. **Read** the target tutorial from `docs/` in the project workspace
+2. **Extract** every actionable step (commands, file writes, expected outputs)
+3. **Execute** each step sequentially in `$WORK`, writing files exactly as shown
+4. **Verify** after each step: check exit codes, file existence, test passes
+5. **On failure**: record it, attempt to continue with independent steps
+6. **After all steps**: run `./build.sh tests` as final validation
+
+## Input handling
+
+- If called with no arguments or `all`: test all tutorials (quickstart_guide.md, tracksuite_guide.md, then mkdocs build for config docs)
+- If called with a filename: test only that tutorial
+- If called with `config`: run `mkdocs build` to validate markdown-exec blocks
+
+## Output format
+
+Return a structured report:
+
+```
+# Tutorial Test Report
+
+## [Tutorial Name]
+**File:** `docs/xxx.md`
+**Status:** ✅ PASS | ❌ FAIL (N issues)
+**Steps:** X/Y executed successfully
+
+### Failures (if any):
+| # | Step | Error | Root Cause | Proposed Fix |
+|---|------|-------|------------|--------------|
+| 1 | ... | ... | ... | Line X: ... |
+
+### Proposed edits:
+(exact oldString → newString for each fix)
+```
+
+## Rules
+
+- NEVER modify docs files — only propose changes
+- Execute EXACTLY what the tutorial says — silent fixes hide bugs
+- If a step requires network (MARS, git clone from external), skip it and note "requires network"
+- The project source is at the workspace root — read templates/source to diagnose mismatches
+- `./build.sh tests` is the ground truth — if it passes, the suite definition is valid

--- a/docs/api/nodes.md
+++ b/docs/api/nodes.md
@@ -7,3 +7,5 @@
 ::: wellies.tools.DeployToolsFamily
 
 ::: wellies.tools.DeployPackagesFamily
+
+::: wellies.log_archiving.ArchivedRepeatFamily

--- a/docs/api/scripts.md
+++ b/docs/api/scripts.md
@@ -1,3 +1,7 @@
+## Script Loader
+
+::: wellies.scripts.ScriptLoader
+
 ## Mars Request
 
 ::: wellies.mars.Request

--- a/docs/exit_hook.md
+++ b/docs/exit_hook.md
@@ -1,0 +1,148 @@
+# Exit Hooks - Task completion notifications
+
+**pyflow** supports `exit_hook` — shell code that runs in the task cleanup phase,
+regardless of whether the task succeeded or failed. This is the natural place to
+add notifications, log backups, or any post-execution housekeeping.
+
+**wellies** ships a ready-to-use email notification exit hook
+(`email_exit_hook.sh`) that sends formatted emails on task completion or failure.
+It can be loaded using the [wellies.scripts.ScriptLoader][] and passed directly
+to any [pyflow.Task][].
+
+/// admonition | Note
+    type: important
+The email exit hook requires `pyflow>=3.7.0` otherwise there is no way to know, at
+exit time, whether the task succeeded or failed. If you are using an older version
+of pyflow, please upgrade to use this feature.
+///
+
+## Loading and using the email exit hook
+
+The [ScriptLoader][wellies.scripts.ScriptLoader] loads packaged shell snippets
+and returns a [pyflow.Script][] object that can be passed to the `exit_hook`
+parameter of any task.
+
+```python title="suite.py" exec="true" source="above" session="exit_hook" id="exit_hook_load"
+import pyflow as pf
+import wellies as wl
+from wellies.scripts import ScriptLoader
+
+# Load the packaged email exit hook
+email_hook = ScriptLoader().load("email_exit_hook.sh")
+```
+
+## Attaching to a task
+
+Pass the loaded script as the `exit_hook` parameter. The hook requires two
+ecflow variables to be defined — `MAIL_TYPE` and `MAIL_USER` — which control
+when and to whom notifications are sent.
+
+```python title="suite.py" exec="true" source="above" session="exit_hook" id="exit_hook_task"
+with pf.Suite(
+    name="notify_suite",
+    files=".",
+    host=pf.LocalHost(),
+    variables=dict(
+        MAIL_TYPE="FAIL",           # (1)!
+        MAIL_USER="ops@example.com" # (2)!
+    ),
+) as suite:
+
+    task = pf.Task(
+        name="process_data",
+        script=["echo 'Processing data...'"],
+        exit_hook=email_hook,  # (3)!
+    )
+```
+
+1. `MAIL_TYPE` controls when emails are sent: `"ALL"` for every completion,
+   `"FAIL"` for failures only.
+2. `MAIL_USER` is the recipient email address.
+3. The exit hook is appended to the task's cleanup section automatically by
+   pyflow.
+
+## Configuration variables
+
+The email exit hook reads the following ecflow variables at runtime:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `MAIL_TYPE` | Yes | When to send emails: `ALL` (always) or `FAIL` (only on non-zero exit) |
+| `MAIL_USER` | Yes | Recipient email address |
+| `ECF_NAME` | Auto | Task path (set by ecflow) |
+| `ECF_HOST` | Auto | Server host (set by ecflow) |
+| `ECF_TRYNO` | Auto | Attempt number (set by ecflow) |
+| `ECF_JOB` | Auto | Job file path (set by ecflow) |
+| `ECF_JOBOUT` | Auto | Job output path (set by ecflow) |
+
+Variables marked **Auto** are provided by the ecflow framework and do not need
+to be defined by the user.
+
+## Email behaviour
+
+The notification format depends on exit status:
+
+- **Success** (`exit code 0`): plain-text email with subject
+  `[SUCCESS] Job /path/to/task completed in attempt N`
+- **Failure** (`exit code ≠ 0`): HTML email with subject
+  `[ABORT] Job /path/to/task failed in attempt N`, including an extracted
+  traceback from the job output file.
+
+/// admonition | Hint
+    type: hint
+The hook uses `sendmail` for HTML emails and `mailx` for plain text. Ensure at
+least one of these is available on the execution host.
+///
+
+## Applying the hook to multiple tasks
+
+Since `MAIL_TYPE` and `MAIL_USER` are ecflow variables, they can be defined at
+any node level (suite, family, or task). This makes it straightforward to enable
+notifications for an entire subtree:
+
+```python title="suite.py" exec="true" source="above" session="exit_hook" id="exit_hook_family"
+with pf.Suite(
+    name="production",
+    files=".",
+    host=pf.LocalHost(),
+    variables=dict(MAIL_TYPE="FAIL", MAIL_USER="team@example.com"),
+) as suite:
+
+    with pf.Family("critical"):
+        pf.Task("step1", script=["echo step1"], exit_hook=email_hook)
+        pf.Task("step2", script=["echo step2"], exit_hook=email_hook)
+
+    with pf.Family("optional"):
+        # Override: no notifications for this family
+        pf.Task(
+            "cleanup",
+            script=["echo cleanup"],
+            exit_hook=email_hook,
+            variables=dict(MAIL_TYPE=""),  # (1)!
+        )
+```
+
+1. Setting `MAIL_TYPE` to an empty string effectively disables the hook for
+   this task, since the guard condition requires a non-empty value.
+
+## Combining multiple exit hooks
+
+The `exit_hook` parameter accepts a list, allowing you to compose several hooks:
+
+```python title="suite.py" exec="true" source="above" session="exit_hook" id="exit_hook_combine"
+custom_hook = pf.Script(["echo 'Custom post-processing done'"])
+
+pf.Task(
+    name="multi_hook",
+    script=["echo 'main work'"],
+    exit_hook=[email_hook, custom_hook],  # Both run at cleanup
+)
+```
+
+/// admonition | See also
+    type: info
+The [wellies.log_archiving.ArchivedRepeatFamily][] class automatically injects
+its own exit hook for backing up job output files when `logs_backup` is
+configured — an example of how exit hooks integrate with higher-level wellies
+components.
+///

--- a/docs/log_archiving.md
+++ b/docs/log_archiving.md
@@ -1,0 +1,165 @@
+# Log Archiving - Managing job outputs with ArchivedRepeatFamily
+
+Operational suites that iterate over dates (or any repeat dimension) accumulate
+large amounts of job output files. The
+[ArchivedRepeatFamily][wellies.log_archiving.ArchivedRepeatFamily] helps manage
+this by:
+
+1. **Backing up** job output and job files to a separate directory after each
+   task completes (via an automatic exit hook).
+2. **Rotating** backed-up logs at the end of each repeat iteration.
+3. Optionally **archiving** old iterations to long-term storage (e.g. ECFS)
+   as compressed tarballs.
+
+## Basic usage
+
+An `ArchivedRepeatFamily` wraps a standard pyflow
+[AnchorFamily][pyflow.AnchorFamily] with a repeat attribute and automatic log
+management. You define it by providing a `repeat_options` dictionary that
+specifies the repeat type and its parameters.
+
+```python title="suite.py" exec="true" source="above" session="log_archive" id="log_archive_basic"
+import pyflow as pf
+from wellies.log_archiving import ArchivedRepeatFamily
+
+repeat = dict(
+    type="RepeatDate",
+    name="YMD",
+    start="2020-01-01",
+    end="2020-01-31",
+)
+
+with pf.Suite("forecast", files=".") as suite:
+    with ArchivedRepeatFamily(
+        name="main",
+        repeat_options=repeat,
+        logs_backup="/scratch/logs/backup",  # (1)!
+    ):
+        pf.Task("fetch", script=["echo fetching data"])
+        pf.Task("run_model", script=["echo running model"])
+
+suite.generate_node()
+```
+
+1. `logs_backup` activates the log management. Without it, the family behaves
+   like a regular repeat family with no log handling.
+
+## What gets generated
+
+When `logs_backup` is provided, the family automatically:
+
+- Injects an **exit hook** into every task that copies `ECF_JOBOUT` and
+  `ECF_JOB` to the backup directory after each task finishes.
+- Adds a **`loop_logs`** task that runs after all other tasks complete,
+  renaming the backup directory with the current repeat value to preserve
+  logs from each iteration.
+
+```python exec="true" session="log_archive" result="shell" id="log_archive_tree"
+print(suite)
+```
+
+## With long-term archival
+
+When `logs_archive` is also provided, an additional **`archive_logs`** task is
+created. It compresses previous iterations into tarballs and uploads them to the
+archive path (using `ecp` for ECFS storage), then cleans up local copies.
+
+
+```python title="suite.py" exec="true" result="python" source="above" session="log_archive_full" id="log_archive_full"
+import pyflow as pf
+from wellies.log_archiving import ArchivedRepeatFamily
+
+repeat = dict(
+    type="RepeatDate",
+    name="YMD",
+    start="2020-01-01",
+    end="2020-01-31",
+)
+
+with pf.Suite("forecast", files=".") as suite:
+    with ArchivedRepeatFamily(
+        name="main",
+        repeat_options=repeat,
+        logs_backup="/scratch/logs/backup",
+        logs_archive="ec:/uid/logs/archive",  # (1)!
+    ):
+        pf.Task("fetch", script=["echo fetching data"])
+        pf.Task("run_model", script=["echo running model"])
+suite.generate_node()
+print(suite)
+```
+
+1. `logs_archive` requires `logs_backup` to also be set — the archival task
+   operates on the backed-up logs.
+
+## Adding your own tasks and families
+
+`ArchivedRepeatFamily` is a context manager just like any pyflow family. You can
+nest tasks and families freely inside it — they all benefit from the automatic
+log backup exit hook:
+
+```python title="suite.py" exec="true" source="above" result="python" session="log_archive_nested" id="log_archive_nested"
+import pyflow as pf
+from wellies.log_archiving import ArchivedRepeatFamily
+
+repeat = dict(
+    type="RepeatDate",
+    name="YMD",
+    start="2020-06-01",
+    end="2020-06-30",
+)
+
+with pf.Suite("production", files=".") as suite:
+    with ArchivedRepeatFamily(
+        name="main",
+        repeat_options=repeat,
+        logs_backup="/scratch/logs/backup",
+    ):
+        pf.Task("prepare", script=["echo prepare"])
+        with pf.Family("forecast"):
+            pf.Task("run", script=["echo forecast"])
+            pf.Task("post", script=["echo postproc"])
+        pf.Task("verify", script=["echo verify"])
+suite.generate_node()
+print(suite)
+```
+
+## Configuration variables
+
+The following ecflow variables are set automatically by `ArchivedRepeatFamily`:
+
+| Variable | Set when | Description |
+|----------|----------|-------------|
+| `LOGS_BACKUP` | `logs_backup` provided | Path where job files are backed up |
+| `LOGS_ARCHIVE` | `logs_archive` provided | Remote archive path for compressed logs |
+
+## How the exit hook works
+
+The built-in exit hook runs in every task's cleanup phase and performs:
+
+1. Resolves the backup directory from `LOGS_BACKUP`, mirroring the output
+   directory structure.
+2. Creates the backup directory if needed.
+3. Copies the job output (`ECF_JOBOUT`) and job script (`ECF_JOB`) into it.
+
+/// admonition | Combining with other exit hooks
+    type: hint
+You can pass additional exit hooks via the `exit_hook` parameter — they will be
+combined with the log backup hook automatically:
+
+```python
+from wellies.scripts import ScriptLoader
+
+email_hook = ScriptLoader().load("email_exit_hook.sh")
+
+with ArchivedRepeatFamily(
+    name="main",
+    repeat_options=repeat,
+    logs_backup="/scratch/logs/backup",
+    exit_hook=[email_hook],  # Combined with the built-in log backup hook
+):
+    ...
+```
+
+See [Exit Hooks](exit_hook.md) for more on email notifications.
+///

--- a/docs/quickstart_guide.md
+++ b/docs/quickstart_guide.md
@@ -210,7 +210,7 @@ ecflow_variables:
 To deploy the updated suite we do
 
 ```shell
-$ ./deploy.py configs/*.yaml
+$ ./build.sh user
 Running on host: localhost
 ------------------------------------------------------
 Staging suite to /tmp/build_efas_report_k52s_1ra
@@ -276,8 +276,8 @@ model runs. In our example we can add configuration options accordingly:
 
 ```yaml title="config.yaml"
 n_cycles: 2
-start_date: 2024-01-01
-end_date: 2024-01-07
+start_date: "20240101"
+end_date: "20240107"
 ```
 
 Next we use wellies to configure a MARS request. We give each request a name, a type, here `mars` and a request body.
@@ -346,6 +346,7 @@ class Config:
             args.profiles,
             config_name=args.name,
             set_variables=args.set,
+            global_vars=self.global_vars,
         )
 
         # put everything from the yaml into class variables
@@ -376,6 +377,7 @@ class Config:
             args.profiles,
             config_name=args.name,
             set_variables=args.set,
+            global_vars=self.global_vars,
         )
 
         # put everything from the yaml into class variables
@@ -385,8 +387,8 @@ class Config:
         self.ecflow_server = wl.EcflowServer(**options["ecflow_server"])
 
         self.cycles = range(0, 24, 24 // options.get('n_cycles', 1))
-        self.start_date = dt.strptime(options['start_date'], "%Y-%m-%d")
-        self.end_date = dt.strptime(options['start_date'], "%Y-%m-%d")
+        self.start_date = dt.strptime(options['start_date'], "%Y%m%d")
+        self.end_date = dt.strptime(options['end_date'], "%Y%m%d")
 
         self.fc_retrievals = [
             wl.data.parse_data_item("$OUTPUT_ROOT", entry['name'], entry)
@@ -443,7 +445,7 @@ class MainFamily(pf.AnchorFamily):
                 f_issue = IssueFamily(config, cycle)
                 if f_previous is not None:
                     f_issue.triggers = f_previous.complete
-                    f_previous = f_issue
+                f_previous = f_issue
 ```
 
 For readability we also define an `IssueFamily` class that holds the logic of a
@@ -462,16 +464,14 @@ tools:
       version: 2024.09.0.0
       depends: [python]
   packages:
-    earthkit:
-      type: git
-      source: git@github.com:ecmwf/earthkit-data.git
-      branch: develop
-      post_script: "pip install . --no-deps"
+    scripts:
+      type: rsync
+      source: "{ROOT}/scripts"
   environments:
       suite_env:
           type: system_venv
           depends: [python, ecmwf-toolbox]
-          packages: [earthkit]
+          packages: [scripts]
 ```
 
 We're now able to add the loading of the `ecmwf-toolbox` module to our script using the `config.tools.load('ecmwf-toolbox')`
@@ -489,14 +489,169 @@ n_ret = pf.Task(
 
 For more detail on using tools see the [tools documentation](./config/tools_config.md).
 
-We've now defined most of the components of the suite:
+We've now defined most of the components of the suite. The remaining piece
+is the actual plotting task that produces our EFAS-style report maps.
 
-# TODO's
+## Creating the plotting script
 
-- Update paths to real files so the tutorial can be run end to end.
-- Show jupyter notebook that run earthkit maps plotting for efas data.
-- Create script that runs with arguments appropriate
-- the main configuration of the suite
-- the host specifications
-- the data that will be retrieved by the suite
-- the details of the environment that will run in our tasks
+Our `plots` task needs a script that reads the retrieved GRIB data and produces
+a map for each forecast step. We'll create a Python script based on
+[earthkit-plots](https://earthkit-plots.readthedocs.io/en/stable/examples/gallery/gridded-data/efas.html)
+and wrap it in a bash launcher that the ecflow task will call.
+
+First, create the plotting script in your project's `efas_report/scripts/` directory:
+
+```python title="efas_report/scripts/plot_efas.py"
+"""Produce an EFAS-style discharge map for a single forecast step."""
+import sys
+from pathlib import Path
+
+import earthkit.data
+import earthkit.plots
+
+def plot_step(input_file, output_dir, step):
+    """Plot a single forecast step and save as PNG."""
+    ds = earthkit.data.from_source("file", input_file)
+    field = ds.sel(step=step)
+
+    chart = earthkit.plots.Map()
+    chart.plot(field)
+    chart.title(f"EFAS Report - T+{step}h")
+
+    output_path = Path(output_dir) / f"efas_step_{step:03d}.png"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    chart.save(str(output_path))
+    print(f"Saved: {output_path}")
+
+if __name__ == "__main__":
+    plot_step(
+        input_file=sys.argv[1],
+        output_dir=sys.argv[2],
+        step=int(sys.argv[3]),
+    )
+```
+
+Then create the bash wrapper that ecflow will execute. This iterates over
+forecast steps for the current date and cycle:
+
+```bash title="efas_report/scripts/run_plots.sh"
+#!/bin/bash
+# Run plotting for all forecast steps
+# Variables YMD, HH, STEPS are provided by ecflow
+
+INPUT_DIR="$OUTPUT_ROOT/data/$YMD/$HH"
+OUTPUT_DIR="$OUTPUT_ROOT/plots/$YMD/$HH"
+
+for STEP in $STEPS; do
+    INPUT_FILE="$INPUT_DIR/forecast_step_${STEP}.grib"
+    python $LIB_DIR/scripts/plot_efas.py "$INPUT_FILE" "$OUTPUT_DIR" "$STEP"
+done
+
+echo "All plots complete for $YMD cycle $HH"
+```
+
+## Wiring the script into the suite
+
+Now we update the `plots` task in our `IssueFamily` to execute the wrapper
+script, loading the required tools environment first:
+
+```python title="nodes.py"
+class IssueFamily(pf.Family):
+    def __init__(self, config, hh, **kwargs):
+        hh_label = f"{hh:02.0f}"
+        variables = kwargs.pop('variables', {})
+        variables.update(dict(HH=hh_label, STEPS="6 12 18 24 48 72"))
+        super().__init__(name=hh_label, variables=variables, **kwargs)
+        with self:
+            # retrieve data
+            n_ret = pf.Task(
+                name='retrieve',
+                script=[
+                    config.tools.load('ecmwf-toolbox'),
+                    [dd.script for dd in config.fc_retrievals],
+                ],
+            )
+            # run report
+            n_plt = pf.Task(
+                name='plots',
+                script=[
+                    config.tools.load('suite_env'),
+                    "bash $LIB_DIR/scripts/run_plots.sh",
+                ],
+            )
+        n_plt.triggers = n_ret.complete
+```
+
+The `scripts/` directory needs to be declared in `tools.yaml` as a package so
+it gets deployed alongside the suite (already done in our earlier configuration).
+
+## Deploying and running the suite
+
+With all components in place, deploy the suite using the build script:
+
+```shell
+$ ./build.sh user
+```
+
+This will:
+
+1. Parse the `user` profile (defined in `profiles.yaml`) to load all config files.
+2. Generate the ecflow suite definition including all tasks, triggers, and scripts.
+3. Deploy scripts and definitions to the configured output directories.
+
+To generate the suite without deploying (useful for local inspection):
+
+```shell
+$ ./build.sh user -n
+```
+
+/// admonition | Tip
+    type: tip
+Use `-y` to skip interactive confirmation prompts during deployment, e.g.
+`./build.sh user -y`.
+///
+
+## Testing locally
+
+The generated project includes a test suite that validates your configuration
+builds correctly:
+
+```shell
+$ ./build.sh tests
+```
+
+This runs pytest against your suite definitions, ensuring all profiles produce
+valid ecflow definitions without needing access to the actual server.
+
+## Summary
+
+In this tutorial we built a complete operational suite that:
+
+- **Retrieves** forecast data from MARS for multiple cycles per day
+- **Processes** each forecast step through a plotting pipeline
+- **Manages** dependencies so plotting waits for data retrieval
+- **Deploys** tools, environments, and static data automatically via wellies
+
+The key wellies features used were:
+
+| Feature | Purpose |
+|---------|---------|
+| `wellies-quickstart` | Scaffold the project structure |
+| `Config` + YAML profiles | Separate configuration from logic |
+| `ToolStore` + environments | Manage software dependencies |
+| `StaticDataStore` + MARS | Declare and deploy input data |
+| `DeployToolsFamily` / `DeployDataFamily` | Automated initialisation tasks |
+
+## Next steps
+
+Here are some challenges to extend the suite further:
+
+1. **Add a verification step** — create a new task that compares today's
+   forecast plots against yesterday's and flags anomalies.
+2. **Archive logs** — wrap `MainFamily` in an
+   [ArchivedRepeatFamily](log_archiving.md) to manage job output files
+   across repeat iterations.
+3. **Add email notifications** — use the [email exit hook](exit_hook.md)
+   to get notified when plotting tasks fail.
+4. **Multi-host execution** — configure a second host in `host.yaml` and
+   run retrievals on a data-access node while plots run on a compute node.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,8 @@ nav:
   - Tutorials:
     - Building a new suite: quickstart_guide.md
     - Git-tracked deployment: tracksuite_guide.md
+    - Exit Hooks: exit_hook.md
+    - Log Archiving: log_archiving.md
   #- How to guides:
   - API:
     - Suite Building: api/config.md


### PR DESCRIPTION
### Description
This pull request introduces a new automated tutorial testing system for the documentation, adds comprehensive documentation for exit hooks and log archiving, and makes several corrections and improvements to the quickstart guide and API docs. The most significant changes are the addition of a "tutorial-testing" skill and agent, new documentation for log management features, and updates to ensure tutorial steps and configurations are accurate and reproducible.

**Automated Tutorial Testing**

* Added `.claude/skills/tutorial-testing/SKILL.md` defining a "tutorial-testing" skill that executes documentation tutorials step-by-step in a temp directory, detects failures, and proposes fixes, with detailed protocol and reporting format.
* Introduced `.opencode/commands/test-tutorial.md` as a subagent command to automate tutorial validation, specifying environment setup, workflow, and output rules.
* Linked the above command in `.claude/commands/test-tutorial.md` for integration.

**Documentation: Log Archiving and Exit Hooks**

* Added `docs/log_archiving.md` describing the `ArchivedRepeatFamily` class for automatic job log backup and archiving, including usage examples, configuration, and integration with other exit hooks.
* Added `docs/exit_hook.md` providing detailed instructions for using exit hooks (especially email notifications) via `ScriptLoader`, with configuration, usage patterns, and integration notes.
* Updated API docs to include `wellies.log_archiving.ArchivedRepeatFamily` and `wellies.scripts.ScriptLoader`. [[1]](diffhunk://#diff-1f06123df8a85299f4b90823b507402b86fa23169d5eafbe4815ba76546ff4e5R10-R11) [[2]](diffhunk://#diff-84838f34a4d57afad4b121b5c12a75f17405c8eece27a40c82e75f79b1fd683aR1-R4)

**Quickstart Guide Corrections and Improvements**

* Updated deployment instructions to use `./build.sh user` instead of `./deploy.py configs/*.yaml`.
* Changed date formats in YAML and Python code from `%Y-%m-%d` to `%Y%m%d` for consistency and correctness, and fixed a bug where `end_date` was incorrectly set. [[1]](diffhunk://#diff-0f06746f2e2b795a11bfcfae7d58c902f707923a4093cd9797c2c823ffba5180L279-R280) [[2]](diffhunk://#diff-0f06746f2e2b795a11bfcfae7d58c902f707923a4093cd9797c2c823ffba5180L388-R391)
* Passed `global_vars` to the configuration loader for improved variable management. [[1]](diffhunk://#diff-0f06746f2e2b795a11bfcfae7d58c902f707923a4093cd9797c2c823ffba5180R349) [[2]](diffhunk://#diff-0f06746f2e2b795a11bfcfae7d58c902f707923a4093cd9797c2c823ffba5180R380)
* Updated tool/package configuration to use a `scripts` package via `rsync` instead of a git dependency on `earthkit`, and adjusted environment package list accordingly.

These changes collectively improve the reliability of tutorials, enhance documentation of operational features, and ensure the quickstart guide is accurate and reproducible.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- readthedocs-preview pyflow-wellies start -->
----
📚 Documentation preview 📚: https://pyflow-wellies--70.org.readthedocs.build/70/

<!-- readthedocs-preview pyflow-wellies end -->